### PR TITLE
add error listener to subscriptions so we can catch if there is an error subscribing

### DIFF
--- a/src/current_user.ts
+++ b/src/current_user.ts
@@ -126,6 +126,7 @@ export default class CurrentUser {
 
     this.apiInstance.subscribeNonResuming({
       listeners: {
+        onError: delegate && delegate.error,
         onEvent: this.presenceSubscription.handleEvent.bind(
           this.presenceSubscription,
         ),
@@ -498,6 +499,7 @@ export default class CurrentUser {
 
     this.apiInstance.subscribeNonResuming({
       listeners: {
+        onError: roomDelegate.error,
         onEvent: room.subscription.handleEvent.bind(room.subscription),
       },
       path: `/rooms/${room.id}?message_limit=${messageLimit}`,

--- a/src/room_delegate.ts
+++ b/src/room_delegate.ts
@@ -14,6 +14,8 @@ interface RoomDelegate {
 
   // TODO: This seems like it could instead be `userListUpdated`, or something similar?
   usersUpdated?: () => void;
+
+  error?: (error: any) => void;
 }
 
 export default RoomDelegate;


### PR DESCRIPTION
@hamchapman I saw there were a load of comments about how we might want to do error handling going forward... so this isn't necessarily a permanent solution, but at least makes it possible to find out if there is an error opening a subscription (which currently is a silent failure)