### PR TITLE
Get own cursors on connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ This project adheres to [Semantic Versioning Scheme](http://semver.org)
 
 ---
 
+## Unreleased (branch: get-own-cursors-on-connection)
+
+### Changes
+
+- `ChatManager` takes a `userId` as a required option, `TokenProvider` no
+  longer does. (`ChatManager` passes the user ID to the token provider
+  internally before requesting a token.)
+
+### Additions
+
+- `RoomDelegate` has a `cursorSet` callback, fired whenever a cursor is set in
+  the given room.
+
+- `CurrentUser` has a `setCursor` method, to set a cursor in a given room.
+
+- The `CurrentUser` object now has a `cursors` property, which contains all the
+  user's own cursors, mapped by room ID. This is guaranteed to be populated
+  before room subscriptions succeed, so e.g. `currentUser.cursors[roomId]` can
+  be used upon receiving messages to determine if they have been read already.
+
 ## Unreleased
 
 ### Changes

--- a/src/chat_manager.ts
+++ b/src/chat_manager.ts
@@ -19,14 +19,14 @@ export interface ChatManagerOptions {
   tokenProvider: TokenProvider;
   logger?: Logger;
   baseClient?: BaseClient;
-  userId?: string;
+  userId: string;
 }
 
 export default class ChatManager {
   apiInstance: Instance;
   filesInstance: Instance;
   cursorsInstance: Instance;
-  userId?: string;
+  userId: string;
 
   private userStore: GlobalUserStore;
   private userSubscription: UserSubscription;
@@ -77,23 +77,21 @@ export default class ChatManager {
   }
 
   connect(options: ConnectOptions) {
-    const cursorsReq: Promise<any> = this.userId
-      ? this.cursorsInstance
-          .request({
-            method: 'GET',
-            path: `/cursors/0/users/${this.userId}`,
-          })
-          .then(res => {
-            const cursors = JSON.parse(res);
-            const cursorsByRoom: { [roomId: number]: BasicCursor } = {};
-            cursors.forEach((c: any): void => {
-              cursorsByRoom[
-                c.room_id
-              ] = PayloadDeserializer.createBasicCursorFromPayload(c);
-            });
-            return cursorsByRoom;
-          })
-      : Promise.resolve({});
+    const cursorsReq: Promise<any> = this.cursorsInstance
+      .request({
+        method: 'GET',
+        path: `/cursors/0/users/${this.userId}`,
+      })
+      .then(res => {
+        const cursors = JSON.parse(res);
+        const cursorsByRoom: { [roomId: number]: BasicCursor } = {};
+        cursors.forEach((c: any): void => {
+          cursorsByRoom[
+            c.room_id
+          ] = PayloadDeserializer.createBasicCursorFromPayload(c);
+        });
+        return cursorsByRoom;
+      });
 
     this.userSubscription = new UserSubscription({
       apiInstance: this.apiInstance,

--- a/src/chat_manager.ts
+++ b/src/chat_manager.ts
@@ -77,7 +77,9 @@ export default class ChatManager {
   }
 
   connect(options: ConnectOptions) {
-    const cursorsReq: Promise<any> = this.cursorsInstance
+    const cursorsReq: Promise<{
+      [roomId: number]: BasicCursor;
+    }> = this.cursorsInstance
       .request({
         method: 'GET',
         path: `/cursors/0/users/${this.userId}`,
@@ -97,12 +99,17 @@ export default class ChatManager {
       apiInstance: this.apiInstance,
       connectCompletionHandler: (currentUser?: CurrentUser, error?: any) => {
         if (currentUser) {
-          cursorsReq
+          currentUser.cursorsReq = cursorsReq
             .then(cursors => {
               currentUser.cursors = cursors;
-              options.onSuccess(currentUser);
             })
-            .catch(options.onError);
+            .catch(err => {
+              this.cursorsInstance.logger.verbose(
+                'Error getting cursors:',
+                err,
+              );
+            });
+          options.onSuccess(currentUser);
         } else {
           options.onError(error);
         }

--- a/src/chat_manager.ts
+++ b/src/chat_manager.ts
@@ -1,11 +1,17 @@
-import { BaseClient, HOST_BASE, Instance, Logger } from 'pusher-platform';
+import {
+  BaseClient,
+  HOST_BASE,
+  Instance,
+  Logger,
+  TokenProvider,
+} from 'pusher-platform';
 
 import BasicCursor from './basic_cursor';
 import ChatManagerDelegate from './chat_manager_delegate';
 import CurrentUser from './current_user';
 import GlobalUserStore from './global_user_store';
 import PayloadDeserializer from './payload_deserializer';
-import TokenProvider from './token_provider';
+import CKTokenProvider from './token_provider';
 import UserSubscription from './user_subscription';
 
 export interface ChatManagerOptions {
@@ -39,7 +45,9 @@ export default class ChatManager {
         logger: options.logger,
       });
 
-    options.tokenProvider.userId = this.userId;
+    if (options.tokenProvider instanceof CKTokenProvider) {
+      options.tokenProvider.userId = this.userId;
+    }
     const sharedInstanceOptions = {
       client: baseClient,
       locator: options.instanceLocator,

--- a/src/current_user.ts
+++ b/src/current_user.ts
@@ -1,5 +1,6 @@
 import { Instance, sendRawRequest } from 'pusher-platform';
 
+import BasicCursor from './basic_cursor';
 import BasicMessage from './basic_message';
 import BasicMessageEnricher from './basic_message_enricher';
 import ChatManagerDelegate from './chat_manager_delegate';
@@ -81,6 +82,7 @@ export interface CompleteMessageOptions {
 export default class CurrentUser {
   id: string;
   createdAt: string;
+  cursors?: { [roomId: string]: BasicCursor };
   updatedAt: string;
   name?: string;
   avatarURL?: string;

--- a/src/current_user.ts
+++ b/src/current_user.ts
@@ -514,7 +514,6 @@ export default class CurrentUser {
     }
   }
 
-  // TODO: Do I need to add a Last-Event-ID option here?
   subscribeToRoom(room: Room, roomDelegate: RoomDelegate, messageLimit = 20) {
     this.cursorsReq.then(() => {
       room.subscription = new RoomSubscription({
@@ -526,9 +525,6 @@ export default class CurrentUser {
         delegate: roomDelegate,
         logger: this.apiInstance.logger,
       });
-
-      // TODO: What happens if you provide both a message_limit and a Last-Event-ID?
-
       this.apiInstance.subscribeNonResuming({
         listeners: {
           onError: roomDelegate.error,
@@ -536,7 +532,6 @@ export default class CurrentUser {
         },
         path: `/rooms/${room.id}?message_limit=${messageLimit}`,
       });
-
       this.subscribeToCursors(room, roomDelegate);
     });
   }

--- a/src/current_user.ts
+++ b/src/current_user.ts
@@ -740,6 +740,11 @@ export default class CurrentUser {
   private subscribeToCursors(room: Room, roomDelegate: RoomDelegate) {
     room.cursorSubscription = new CursorSubscription({
       delegate: roomDelegate,
+      handleCursorSetInternal: (cursor: BasicCursor) => {
+        if (cursor.userId === this.id && this.cursors !== undefined) {
+          this.cursors[cursor.roomId] = cursor;
+        }
+      },
       logger: this.cursorsInstance.logger,
       room,
       userStore: this.userStore,

--- a/src/cursor_subscription.ts
+++ b/src/cursor_subscription.ts
@@ -29,7 +29,7 @@ export default class CursorSubscription {
 
   handleEvent(event: SubscriptionEvent) {
     if (!this.delegate || !this.delegate.cursorSet) {
-      return
+      return;
     }
     const { body, eventId, headers } = event;
     const { data } = body;

--- a/src/cursor_subscription.ts
+++ b/src/cursor_subscription.ts
@@ -12,6 +12,7 @@ export interface CursorSubscriptionOptions {
   logger: Logger;
   room: Room;
   userStore: GlobalUserStore;
+  handleCursorSetInternal: (cursor: BasicCursor) => void;
 }
 
 export default class CursorSubscription {
@@ -19,12 +20,14 @@ export default class CursorSubscription {
   logger: Logger;
   room: Room;
   userStore: GlobalUserStore;
+  handleCursorSetInternal: (cursor: BasicCursor) => void;
 
   constructor(options: CursorSubscriptionOptions) {
     this.delegate = options.delegate;
     this.logger = options.logger;
     this.room = options.room;
     this.userStore = options.userStore;
+    this.handleCursorSetInternal = options.handleCursorSetInternal;
   }
 
   handleEvent(event: SubscriptionEvent) {
@@ -43,6 +46,7 @@ export default class CursorSubscription {
     this.logger.verbose(`Received event name: ${eventName}, and data: ${data}`);
     const basicCursor = PayloadDeserializer.createBasicCursorFromPayload(data);
     this.logger.verbose(`Room received cursor for: ${basicCursor.userId}`);
+    this.handleCursorSetInternal(basicCursor);
     this.enrich(
       basicCursor,
       cursor => {

--- a/src/cursor_types.ts
+++ b/src/cursor_types.ts
@@ -1,5 +1,5 @@
 enum CursorType {
   Read,
-};
+}
 
 export default CursorType;

--- a/src/token_provider.ts
+++ b/src/token_provider.ts
@@ -1,4 +1,7 @@
-import { sendRawRequest } from 'pusher-platform';
+import {
+  sendRawRequest,
+  TokenProvider as PlatformTokenProvider,
+} from 'pusher-platform';
 
 import { mergeQueryParamsIntoUrl, urlEncode } from './utils';
 
@@ -20,7 +23,7 @@ export interface TokenProviderOptions {
   url: string;
 }
 
-export default class TokenProvider {
+export default class TokenProvider implements PlatformTokenProvider {
   authContext?: TokenProviderAuthContextOptions;
   url: string;
   userId?: string;

--- a/src/token_provider.ts
+++ b/src/token_provider.ts
@@ -18,7 +18,6 @@ export type TokenProviderAuthContextQueryParams = {
 export interface TokenProviderOptions {
   authContext?: TokenProviderAuthContextOptions;
   url: string;
-  userId?: string;
 }
 
 export default class TokenProvider {
@@ -32,7 +31,6 @@ export default class TokenProvider {
   constructor(options: TokenProviderOptions) {
     this.authContext = options.authContext || {};
     this.url = options.url;
-    this.userId = options.userId;
   }
 
   get cacheIsStale() {


### PR DESCRIPTION
The basic flow works here. Gets cursors and makes user subscription simultaneously, and then call `onSuccess` with a `currentUser` object that has been augmented with a `cursors` property. The interface probably needs some work though, I'm currently passing `userId` in to `ChatManager` so that I have access to it to  make the GET request to cursors, I do think the request should be done at this point, because having access to your cursors can block handling messages on a room subscription if you want to know which one's you've already seen.

Also, do we need to polyfill promises / use explicit callbacks, or does typescript do that for you?