### PR TITLE
Make message limit optional

### DIFF
--- a/src/current_user.ts
+++ b/src/current_user.ts
@@ -533,6 +533,9 @@ export default class CurrentUser {
   subscribeToRoom(room: Room, roomDelegate: RoomDelegate, messageLimit?: number) {
     const path = `/rooms/${room.id}`;
     if (messageLimit !== undefined) {
+      if (typeof messageLimit !== "number") {
+        thow new Error(`Message limit should be a valid number`);
+      }
       path = `${path}?message_limit=${messageLimit}`;
     }
 

--- a/src/current_user.ts
+++ b/src/current_user.ts
@@ -530,7 +530,12 @@ export default class CurrentUser {
     }
   }
 
-  subscribeToRoom(room: Room, roomDelegate: RoomDelegate, messageLimit = 20) {
+  subscribeToRoom(room: Room, roomDelegate: RoomDelegate, messageLimit?: number) {
+    const path = `/rooms/${room.id}`;
+    if (messageLimit !== undefined) {
+      path = `${path}?message_limit=${messageLimit}`;
+    }
+
     this.cursorsReq.then(() => {
       room.subscription = new RoomSubscription({
         basicMessageEnricher: new BasicMessageEnricher(
@@ -546,7 +551,7 @@ export default class CurrentUser {
           onError: roomDelegate.error,
           onEvent: room.subscription.handleEvent.bind(room.subscription),
         },
-        path: `/rooms/${room.id}?message_limit=${messageLimit}`,
+        path: path,
       });
       this.subscribeToCursors(room, roomDelegate);
     });


### PR DESCRIPTION
The default for message limit is 20 anyway and is set server side. So not passing it in will have the same effect.

This also makes the argument be of `number` type. Previously anyone could pass anything and we didn't have checks either.