### PR TITLE
Error on missing user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ This project adheres to [Semantic Versioning Scheme](http://semver.org)
 - Made sure that the `messageLimit` argument in `subscribeToRoom` was being validated as a number.
 - Ensured that the `position` argument in `setCursor` is a valid number.
 
+### Additions
+
+- Throw an error if the userId isn't provided to the ChatManager
+
 ## 0.6.0 -- 2018-01-19
 
 ### Changes

--- a/src/chat_manager.ts
+++ b/src/chat_manager.ts
@@ -32,6 +32,9 @@ export default class ChatManager {
   private userSubscription: UserSubscription;
 
   constructor(options: ChatManagerOptions) {
+    if (typeof options.userId !== 'string') {
+      throw new Error('Please provide a userId to the ChatManger constructor!');
+    }
     this.userId = options.userId;
     const splitInstanceLocator = options.instanceLocator.split(':');
     if (splitInstanceLocator.length !== 3) {

--- a/src/current_user.ts
+++ b/src/current_user.ts
@@ -462,8 +462,8 @@ export default class CurrentUser {
     onSuccess: () => void,
     onError: (error: any) => void,
   ) {
-    if (typeof position !== "number") {
-      throw new Error("Cursor position should be a valid number");
+    if (typeof position !== 'number') {
+      throw new Error('Cursor position should be a valid number');
     }
 
     this.cursorsInstance
@@ -534,11 +534,15 @@ export default class CurrentUser {
     }
   }
 
-  subscribeToRoom(room: Room, roomDelegate: RoomDelegate, messageLimit?: number) {
-    const path = `/rooms/${room.id}`;
+  subscribeToRoom(
+    room: Room,
+    roomDelegate: RoomDelegate,
+    messageLimit?: number,
+  ) {
+    let path = `/rooms/${room.id}`;
     if (messageLimit !== undefined) {
-      if (typeof messageLimit !== "number") {
-        thow new Error(`Message limit should be a valid number`);
+      if (typeof messageLimit !== 'number') {
+        throw new Error('Message limit should be a valid number');
       }
       path = `${path}?message_limit=${messageLimit}`;
     }
@@ -558,7 +562,7 @@ export default class CurrentUser {
           onError: roomDelegate.error,
           onEvent: room.subscription.handleEvent.bind(room.subscription),
         },
-        path: path,
+        path,
       });
       this.subscribeToCursors(room, roomDelegate);
     });


### PR DESCRIPTION
Throws an error if the consumer fails to provide a `userId` to the `ChatManager` constructor. Also fixes a load of build and lint errors that were in master. Gotta remember to `yarn build && yarn lint && yarn format`! 😉 