### PR TITLE
catch error parsing cursors request earlier

### DIFF
--- a/src/chat_manager.ts
+++ b/src/chat_manager.ts
@@ -96,6 +96,13 @@ export default class ChatManager {
           ] = PayloadDeserializer.createBasicCursorFromPayload(c);
         });
         return cursorsByRoom;
+      })
+      .catch(err => {
+        this.cursorsInstance.logger.verbose(
+          'Error getting cursors:',
+          err,
+        );
+        return {}
       });
 
     this.userSubscription = new UserSubscription({
@@ -105,12 +112,6 @@ export default class ChatManager {
           currentUser.cursorsReq = cursorsReq
             .then(cursors => {
               currentUser.cursors = cursors;
-            })
-            .catch(err => {
-              this.cursorsInstance.logger.verbose(
-                'Error getting cursors:',
-                err,
-              );
             });
           options.onSuccess(currentUser);
         } else {


### PR DESCRIPTION
fix for #25 

Catch block wasn't added to the promise chain until after it had already been invoked, leading to any errors being thrown to the console.