### PR TITLE
Vanilla cursors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ yarn-error.log
 .DS_Store
 .vscode/
 tests/config.js
+tests/config.us1.js
+tests/config.deneb.js

--- a/src/chat-manager.js
+++ b/src/chat-manager.js
@@ -57,8 +57,8 @@ export class ChatManager {
     })
     return Promise.all([
       currentUser.establishUserSubscription(hooks),
-      currentUser.establishPresenceSubscription(hooks)
-      // currentUser.establishCursorsSubscription(hooks)
+      currentUser.establishPresenceSubscription(hooks),
+      currentUser.establishCursorSubscription(hooks)
     ]).then(() => currentUser)
   }
 }

--- a/src/chat-manager.js
+++ b/src/chat-manager.js
@@ -52,12 +52,13 @@ export class ChatManager {
     const currentUser = new CurrentUser({
       id: this.userId,
       apiInstance: this.apiInstance,
-      filesInstance: this.filesInstance
+      filesInstance: this.filesInstance,
+      cursorsInstance: this.cursorsInstance
     })
     return Promise.all([
       currentUser.establishUserSubscription(hooks),
       currentUser.establishPresenceSubscription(hooks)
-      // currentUser.initializeCursorStore()
+      // currentUser.establishCursorsSubscription(hooks)
     ]).then(() => currentUser)
   }
 }

--- a/src/current-user.js
+++ b/src/current-user.js
@@ -364,14 +364,20 @@ export class CurrentUser {
       typingIndicators: this.typingIndicators,
       roomSubscriptions: this.roomSubscriptions
     })
-    return this.userSubscription.connect().then(({ user, basicRooms }) => {
-      this.avatarURL = user.avatarURL
-      this.createdAt = user.createdAt
-      this.customData = user.customData
-      this.name = user.name
-      this.updatedAt = user.updatedAt
-      this.roomStore.initialize(indexBy(prop('id'), basicRooms))
-    }).then(this.initializeUserStore)
+    return this.userSubscription.connect()
+      .then(({ user, basicRooms }) => {
+        this.avatarURL = user.avatarURL
+        this.createdAt = user.createdAt
+        this.customData = user.customData
+        this.name = user.name
+        this.updatedAt = user.updatedAt
+        this.roomStore.initialize(indexBy(prop('id'), basicRooms))
+      })
+      .then(this.initializeUserStore)
+      .catch(err => {
+        this.logger.error('error establishing user subscription:', err)
+        throw err
+      })
   }
 
   establishPresenceSubscription = hooks => {
@@ -385,6 +391,10 @@ export class CurrentUser {
       roomSubscriptions: this.roomSubscriptions
     })
     return this.presenceSubscription.connect()
+      .catch(err => {
+        this.logger.warn('error establishing presence subscription:', err)
+        throw err
+      })
   }
 
   establishCursorSubscription = hooks => {
@@ -405,6 +415,10 @@ export class CurrentUser {
     })
     return this.cursorSubscription.connect()
       .then(() => this.cursorStore.initialize({}))
+      .catch(err => {
+        this.logger.warn('error establishing cursor subscription:', err)
+        throw err
+      })
   }
 
   initializeUserStore = () => {
@@ -414,9 +428,7 @@ export class CurrentUser {
       .catch(err => {
         this.logger.warn('error fetching initial user information:', err)
       })
-      .then(() => {
-        this.userStore.initialize({})
-      })
+      .then(() => this.userStore.initialize({}))
   }
 }
 

--- a/src/current-user.js
+++ b/src/current-user.js
@@ -96,14 +96,10 @@ export class CurrentUser {
       })
   }
 
-  getReadCursor = (roomId, userId = this.id) => {
+  readCursor = (roomId, userId = this.id) => {
     typeCheck('roomId', 'number', roomId)
     typeCheck('userId', 'string', userId)
-    return this.cursorStore.get(userId, roomId)
-      .catch(err => {
-        this.logger.warn('error getting cursor:', err)
-        throw err
-      })
+    return this.cursorStore.getSync(userId, roomId)
   }
 
   isTypingIn = roomId => {

--- a/src/current-user.js
+++ b/src/current-user.js
@@ -4,6 +4,7 @@ import {
   compose,
   concat,
   contains,
+  has,
   indexBy,
   map,
   pipe,
@@ -98,6 +99,13 @@ export class CurrentUser {
   readCursor = (roomId, userId = this.id) => {
     typeCheck('roomId', 'number', roomId)
     typeCheck('userId', 'string', userId)
+    if (userId !== this.id && !has(roomId, this.roomSubscriptions)) {
+      const err = new TypeError(
+        `Must be subscribed to room ${roomId} to access member's read cursors`
+      )
+      this.logger.error(err)
+      throw err
+    }
     return this.cursorStore.getSync(userId, roomId)
   }
 

--- a/src/cursor-store.js
+++ b/src/cursor-store.js
@@ -24,6 +24,10 @@ export class CursorStore {
       .then(this.decorate)
   }
 
+  getSync = (userId, roomId) => {
+    return this.decorate(this.store.getSync(key(userId, roomId)))
+  }
+
   fetchBasicCursor = (userId, roomId) => {
     return this.instance
       .request({

--- a/src/cursor-store.js
+++ b/src/cursor-store.js
@@ -1,0 +1,53 @@
+import { Store } from './store'
+import { Cursor } from './cursor'
+import { parseBasicCursor } from './parsers'
+
+export class CursorStore {
+  constructor ({ instance, userStore, roomStore, logger }) {
+    this.instance = instance
+    this.userStore = userStore
+    this.roomStore = roomStore
+    this.logger = logger
+  }
+
+  store = new Store()
+
+  initialize = this.store.initialize
+
+  set = (userId, roomId, cursor) => this.store.set(key(userId, roomId), cursor)
+
+  get = (userId, roomId) => {
+    return this.store.get(key(userId, roomId))
+      .then(cursor => cursor || this.fetchBasicCursor(userId, roomId)
+        .then(cursor => this.set(userId, roomId, cursor))
+      )
+      .then(this.decorate)
+  }
+
+  fetchBasicCursor = (userId, roomId) => {
+    return this.instance
+      .request({
+        method: 'GET',
+        path: `/cursors/0/rooms/${roomId}/users/${encodeURIComponent(userId)}`
+      })
+      .then(res => {
+        const data = JSON.parse(res)
+        if (data) {
+          return this.decorate(parseBasicCursor(data))
+        }
+        return undefined
+      })
+      .catch(err => {
+        this.logger.warn('error fetching cursor:', err)
+        throw err
+      })
+  }
+
+  decorate = basicCursor => {
+    return basicCursor
+      ? new Cursor(basicCursor, this.userStore, this.roomStore)
+      : undefined
+  }
+}
+
+const key = (userId, roomId) => `${userId}/${roomId}`

--- a/src/cursor-subscription.js
+++ b/src/cursor-subscription.js
@@ -1,0 +1,42 @@
+import { parseBasicCursor } from './parsers'
+
+export class CursorSubscription {
+  constructor ({ hooks, path, cursorStore, instance }) {
+    this.hooks = hooks
+    this.path = path
+    this.cursorStore = cursorStore
+    this.instance = instance
+  }
+
+  connect () {
+    return new Promise((resolve, reject) => {
+      this.instance.subscribeNonResuming({
+        path: this.path,
+        listeners: {
+          onOpen: resolve,
+          onError: reject,
+          onEvent: this.onEvent
+        }
+      })
+    })
+  }
+
+  onEvent = ({ body }) => {
+    switch (body.event_name) {
+      case 'cursor_set':
+        this.onCursorSet(body.data)
+        break
+    }
+  }
+
+  onCursorSet = data => {
+    const basicCursor = parseBasicCursor(data)
+    this.cursorStore.set(basicCursor.userId, basicCursor.roomId, basicCursor)
+      .then(() => {
+        if (this.hooks.newCursor) {
+          this.cursorStore.get(basicCursor.userId, basicCursor.roomId)
+            .then(cursor => this.hooks.newCursor(cursor))
+        }
+      })
+  }
+}

--- a/src/cursor-subscription.js
+++ b/src/cursor-subscription.js
@@ -28,8 +28,8 @@ export class CursorSubscription {
       case 'initial_state':
         this.onInitialState(body.data)
         break
-      case 'cursor_set':
-        this.onCursorSet(body.data)
+      case 'new_cursor':
+        this.onNewCursor(body.data)
         break
     }
   }
@@ -42,7 +42,7 @@ export class CursorSubscription {
     this.hooks.subscriptionEstablished()
   }
 
-  onCursorSet = data => {
+  onNewCursor = data => {
     const basicCursor = parseBasicCursor(data)
     this.cursorStore.set(basicCursor.userId, basicCursor.roomId, basicCursor)
       .then(() => {

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -4,7 +4,7 @@ export class Cursor {
     this.updatedAt = basicCursor.updatedAt
     this.userId = basicCursor.userId
     this.roomId = basicCursor.roomId
-    this.cursorType = basicCursor.cursorType
+    this.type = basicCursor.type
     this.userStore = userStore
     this.roomStore = roomStore
   }

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -1,0 +1,19 @@
+export class Cursor {
+  constructor (basicCursor, userStore, roomStore) {
+    this.position = basicCursor.position
+    this.updatedAt = basicCursor.updatedAt
+    this.userId = basicCursor.userId
+    this.roomId = basicCursor.roomId
+    this.cursorType = basicCursor.cursorType
+    this.userStore = userStore
+    this.roomStore = roomStore
+  }
+
+  get user () {
+    return this.userStore.getSync(this.userId)
+  }
+
+  get room () {
+    return this.roomStore.getSync(this.roomId)
+  }
+}

--- a/src/message-subscription.js
+++ b/src/message-subscription.js
@@ -4,7 +4,7 @@ import { parseBasicMessage } from './parsers'
 import { urlEncode } from './utils'
 import { Message } from './message'
 
-export class RoomSubscription {
+export class MessageSubscription {
   constructor (options) {
     this.roomId = options.roomId
     this.hooks = options.hooks

--- a/src/parsers.js
+++ b/src/parsers.js
@@ -53,7 +53,7 @@ export const parseBasicCursor = data => ({
   updatedAt: data.updated_at,
   userId: data.user_id,
   roomId: data.room_id,
-  cursorType: data.cursor_type
+  type: data.cursor_type
 })
 
 const parseMessageAttachment = data => ({

--- a/src/parsers.js
+++ b/src/parsers.js
@@ -13,7 +13,7 @@ export const parseBasicRoom = data => ({
   userIds: data.member_user_ids
 })
 
-export const parseUser = data => ({
+export const parseBasicUser = data => ({
   avatarURL: data.avatar_url,
   createdAt: data.created_at,
   customData: data.custom_data,

--- a/src/parsers.js
+++ b/src/parsers.js
@@ -48,6 +48,14 @@ export const parseFetchedAttachment = data => ({
   ttl: data.ttl
 })
 
+export const parseBasicCursor = data => ({
+  position: data.position,
+  updatedAt: data.updated_at,
+  userId: data.user_id,
+  roomId: data.room_id,
+  cursorType: data.cursor_type
+})
+
 const parseMessageAttachment = data => ({
   link: data.resource_link,
   type: data.type,

--- a/src/presence-subscription.js
+++ b/src/presence-subscription.js
@@ -6,7 +6,7 @@ import {
   indexBy,
   map,
   prop,
-  values
+  toPairs
 } from 'ramda'
 
 import { parsePresence } from './parsers'
@@ -87,13 +87,13 @@ export class PresenceSubscription {
       this.hooks[hookName](user)
     }
     compose(
-      forEach(sub => this.roomStore.get(sub.roomId).then(room => {
+      forEach(([roomId, sub]) => this.roomStore.get(roomId).then(room => {
         if (contains(user.id, room.userIds)) {
           sub.hooks[hookName](user)
         }
       })),
-      filter(sub => sub.hooks[hookName] !== undefined),
-      values
+      filter(([roomId, sub]) => sub.hooks[hookName] !== undefined),
+      toPairs
     )(this.roomSubscriptions)
   }
 }

--- a/src/user-store.js
+++ b/src/user-store.js
@@ -13,6 +13,7 @@ import { appendQueryParam } from './utils'
 import { Store } from './store'
 import { parseUser } from './parsers'
 
+// TODO user object decorated by presence store
 export class UserStore {
   constructor ({ instance, presenceStore, logger }) {
     this.instance = instance
@@ -44,7 +45,6 @@ export class UserStore {
       })
       .catch(err => {
         this.logger.warn('error fetching user information:', err)
-        throw err
       })
   }
 

--- a/src/user-subscription.js
+++ b/src/user-subscription.js
@@ -1,6 +1,6 @@
 import { map, prop } from 'ramda'
 
-import { parseBasicRoom, parseUser } from './parsers'
+import { parseBasicRoom, parseBasicUser } from './parsers'
 
 export class UserSubscription {
   constructor (options) {
@@ -57,7 +57,7 @@ export class UserSubscription {
 
   onInitialState = ({ current_user: userData, rooms: roomsData }) => {
     this.hooks.subscriptionEstablished({
-      user: parseUser(userData),
+      user: parseBasicUser(userData),
       basicRooms: map(parseBasicRoom, roomsData)
     })
   }

--- a/src/user.js
+++ b/src/user.js
@@ -1,0 +1,15 @@
+export class User {
+  constructor (basicUser, presenceStore) {
+    this.avatarURL = basicUser.avatarURL
+    this.createdAt = basicUser.createdAt
+    this.customData = basicUser.customData
+    this.id = basicUser.id
+    this.name = basicUser.name
+    this.updatedAt = basicUser.updatedAt
+    this.presenceStore = presenceStore
+  }
+
+  get presence () {
+    return this.presenceStore.getSync(this.id)
+  }
+}

--- a/tests/main.js
+++ b/tests/main.js
@@ -900,11 +900,23 @@ test(`user left hook [removes Carol from Bob's room]`, t => {
 
 // Cursors
 
-test(`setup [Bob sets his read cursor in Alice's room]`, t => {
-  fetchUser(t, 'bob')
-    .then(bob => bob.joinRoom(alicesRoom.id).then(() => bob))
-    .then(bob => bob.setReadCursor(alicesRoom.id, 128))
-    .then(t.end)
+test(`new read cursor hook [Bob sets his read cursor in Alice's room]`, t => {
+  Promise.all([
+    fetchUser(t, 'bob')
+      .then(bob => bob.joinRoom(alicesRoom.id).then(() => bob)),
+    fetchUser(t, 'alice')
+      .then(alice => alice.subscribeToRoom(alicesRoom.id, {
+        newReadCursor: cursor => {
+          t.equal(cursor.position, 128)
+          t.equal(cursor.user.name, 'Bob')
+          t.equal(cursor.room.name, `Alice's new room`)
+          t.end()
+        }
+      }))
+  ])
+    .then(([bob]) =>
+      bob.setReadCursor(alicesRoom.id, 128)
+    )
     .catch(endWithErr(t))
   t.timeoutAfter(TEST_TIMEOUT)
 })

--- a/tests/main.js
+++ b/tests/main.js
@@ -242,9 +242,8 @@ test('connection resolves with current user object', t => {
 
 test('own read cursor undefined if not set', t => {
   fetchUser(t, 'alice')
-    .then(alice => alice.getReadCursor(alicesRoom.id))
-    .then(cursor => {
-      t.equal(cursor, undefined)
+    .then(alice => {
+      t.equal(alice.readCursor(alicesRoom.id), undefined)
       t.end()
     })
     .catch(endWithErr(t))
@@ -269,8 +268,8 @@ test('new read cursor hook [Alice sets her read cursor in her room]', t => {
 
 test('get own read cursor', t => {
   fetchUser(t, 'alice')
-    .then(alice => alice.getReadCursor(alicesRoom.id))
-    .then(cursor => {
+    .then(alice => {
+      const cursor = alice.readCursor(alicesRoom.id)
       t.equal(cursor.position, 42)
       t.equal(cursor.user.name, 'Alice')
       t.equal(cursor.room.name, `Alice's room`)
@@ -923,8 +922,8 @@ test(`new read cursor hook [Bob sets his read cursor in Alice's room]`, t => {
 
 test(`get another user's read cursor`, t => {
   fetchUser(t, 'alice')
-    .then(alice => alice.getReadCursor(alicesRoom.id, 'bob'))
-    .then(cursor => {
+    .then(alice => {
+      const cursor = alice.readCursor(alicesRoom.id, 'bob')
       t.equal(cursor.position, 128)
       t.equal(cursor.user.name, 'Bob')
       t.equal(cursor.room.name, `Alice's new room`)

--- a/tests/main.js
+++ b/tests/main.js
@@ -868,7 +868,7 @@ test('typing indicators', t => {
       })),
     fetchUser(t, 'carol')
   ])
-  // FIXME This test (and the corresponding room sub one) fail intermittently.
+  // FIXME This test (and the corresponding user sub one) fail intermittently.
   // The corresponding server side test fails too so there might be some kind
   // of race condition in the server. Needs more investigation.
     .then(([x, carol]) => carol.isTypingIn(bobsRoom.id))

--- a/tests/main.js
+++ b/tests/main.js
@@ -325,7 +325,7 @@ test('user came online hook (user sub)', t => {
 // TODO cancel methods so that we can do this, and because we should have them
 // anyway
 
-test.skip('typing indicators (user sub)', t => {
+test('typing indicators (user sub)', t => {
   let started
   Promise.all([
     fetchUser(t, 'alice', {
@@ -343,10 +343,10 @@ test.skip('typing indicators (user sub)', t => {
     }),
     fetchUser(t, 'bob')
   ])
-  // FIXME This test (and the corresponding room sub one) occasionally fail if
-  // isTypingIn is called without this timeout. It would seem that there is a
-  // race condition *somewhere*.
-    .then(([alice, bob]) => setTimeout(() => bob.isTypingIn(bobsRoom.id), 1000))
+  // FIXME This test (and the corresponding room sub one) fail intermittently.
+  // The corresponding server side test fails too so there might be some kind
+  // of race condition in the server. Needs more investigation.
+    .then(([alice, bob]) => bob.isTypingIn(bobsRoom.id))
     .catch(endWithErr(t))
   t.timeoutAfter(TEST_TIMEOUT)
 })
@@ -849,7 +849,7 @@ test('user came online hook', t => {
 // We can't easily test for the user going offline, because the presence
 // subscription in the above test hangs around until it is garbage collected.
 
-test.skip('typing indicators', t => {
+test('typing indicators', t => {
   let started
   Promise.all([
     fetchUser(t, 'alice')
@@ -868,10 +868,10 @@ test.skip('typing indicators', t => {
       })),
     fetchUser(t, 'carol')
   ])
-  // FIXME This test (and the corresponding user sub one) occasionally fail if
-  // isTypingIn is called without this timeout. It would seem that there is a
-  // race condition *somewhere*.
-    .then(([x, carol]) => setTimeout(() => carol.isTypingIn(bobsRoom.id), 1000))
+  // FIXME This test (and the corresponding room sub one) fail intermittently.
+  // The corresponding server side test fails too so there might be some kind
+  // of race condition in the server. Needs more investigation.
+    .then(([x, carol]) => carol.isTypingIn(bobsRoom.id))
     .catch(endWithErr(t))
   t.timeoutAfter(TEST_TIMEOUT)
 })
@@ -912,6 +912,16 @@ test(`new read cursor hook [Bob sets his read cursor in Alice's room]`, t => {
       }))
   ])
     .then(([bob]) => bob.setReadCursor(alicesRoom.id, 128))
+    .catch(endWithErr(t))
+  t.timeoutAfter(TEST_TIMEOUT)
+})
+
+test(`get another user's read cursor before subscribing to a room fails`, t => {
+  fetchUser(t, 'alice')
+    .then(alice => {
+      t.throws(() => alice.readCursor(alicesRoom.id, 'bob'), /subscribe/)
+      t.end()
+    })
     .catch(endWithErr(t))
   t.timeoutAfter(TEST_TIMEOUT)
 })

--- a/tests/main.js
+++ b/tests/main.js
@@ -240,6 +240,46 @@ test('connection resolves with current user object', t => {
 
 // User subscription
 
+test('own read cursor undefined if not set', t => {
+  fetchUser(t, 'alice')
+    .then(alice => alice.getReadCursor(alicesRoom.id))
+    .then(cursor => {
+      t.equal(cursor, undefined)
+      t.end()
+    })
+    .catch(endWithErr(t))
+  t.timeoutAfter(TEST_TIMEOUT)
+})
+
+test('new read cursor hook [Alice sets her read cursor in her room]', t => {
+  Promise.all([fetchUser(t, 'alice'), fetchUser(t, 'alice', {
+    newReadCursor: cursor => {
+      t.equal(cursor.position, 42)
+      t.equal(cursor.user.name, 'Alice')
+      t.equal(cursor.room.name, `Alice's room`)
+      t.end()
+    }
+  })])
+    .then(([mobileAlice, browserAlice]) =>
+      mobileAlice.setReadCursor(alicesRoom.id, 42)
+    )
+    .catch(endWithErr(t))
+  t.timeoutAfter(TEST_TIMEOUT)
+})
+
+test('get own read cursor', t => {
+  fetchUser(t, 'alice')
+    .then(alice => alice.getReadCursor(alicesRoom.id))
+    .then(cursor => {
+      t.equal(cursor.position, 42)
+      t.equal(cursor.user.name, 'Alice')
+      t.equal(cursor.room.name, `Alice's room`)
+      t.end()
+    })
+    .catch(endWithErr(t))
+  t.timeoutAfter(TEST_TIMEOUT)
+})
+
 test(`added to room hook [creates Bob & Bob's room]`, t => {
   let alice
   fetchUser(t, 'alice', {
@@ -859,38 +899,6 @@ test(`user left hook [removes Carol from Bob's room]`, t => {
 })
 
 // Cursors
-
-test('own read cursor undefined if not set', t => {
-  fetchUser(t, 'alice')
-    .then(alice => alice.getReadCursor(alicesRoom.id))
-    .then(cursor => {
-      t.equal(cursor, undefined)
-      t.end()
-    })
-    .catch(endWithErr(t))
-  t.timeoutAfter(TEST_TIMEOUT)
-})
-
-test('set own read cursor [Alice sets her read cursor in her room]', t => {
-  fetchUser(t, 'alice')
-    .then(alice => alice.setReadCursor(alicesRoom.id, 42))
-    .then(t.end)
-    .catch(endWithErr(t))
-  t.timeoutAfter(TEST_TIMEOUT)
-})
-
-test('get own read cursor', t => {
-  fetchUser(t, 'alice')
-    .then(alice => alice.getReadCursor(alicesRoom.id))
-    .then(cursor => {
-      t.equal(cursor.position, 42)
-      t.equal(cursor.user.name, 'Alice')
-      t.equal(cursor.room.name, `Alice's new room`)
-      t.end()
-    })
-    .catch(endWithErr(t))
-  t.timeoutAfter(TEST_TIMEOUT)
-})
 
 test(`setup [Bob sets his read cursor in Alice's room]`, t => {
   fetchUser(t, 'bob')


### PR DESCRIPTION
~depends on https://github.com/pusher/chatkit-cursors/pull/13 being merged and deployed (but can be reviewed in the meantime as the above is deployed on deneb)~ done!

interface:

```javascript
currentUser.setReadCursor(roomId, position)

currentUser.readCursor(roomId) // own cursors (sync)

currentUser.readCursor(roomId, userId) // other user's cursors (after subscribing to the room) (sync)
```

`newReadCursor` hook on both the user sub (gets changes to own cursors) and the room sub (gets changes to other's cursors)