### PR TITLE
Vanilla cancellation

### DIFF
--- a/src/current-user.js
+++ b/src/current-user.js
@@ -35,6 +35,7 @@ import { UserSubscription } from './user-subscription'
 import { PresenceSubscription } from './presence-subscription'
 import { CursorSubscription } from './cursor-subscription'
 import { MessageSubscription } from './message-subscription'
+import { RoomSubscription } from './room-subscription'
 import { Message } from './message'
 
 export class CurrentUser {
@@ -287,9 +288,10 @@ export class CurrentUser {
     typeCheck('roomId', 'number', roomId)
     typeCheckObj('hooks', 'function', hooks)
     messageLimit && typeCheck('messageLimit', 'number', messageLimit)
-    // TODO what is the desired behaviour if there is already a subscription to
-    // this room? Close the old one? Throw an error? Merge the hooks?
-    this.roomSubscriptions[roomId] = {
+    if (this.roomSubscriptions[roomId]) {
+      this.roomSubscriptions[roomId].cancel()
+    }
+    this.roomSubscriptions[roomId] = new RoomSubscription({
       hooks,
       messageSub: new MessageSubscription({
         roomId,
@@ -316,7 +318,7 @@ export class CurrentUser {
         cursorStore: this.cursorStore,
         instance: this.cursorsInstance
       })
-    }
+    })
     return this.joinRoom(roomId)
       .then(room => Promise.all([
         this.roomSubscriptions[roomId].messageSub.connect(),

--- a/src/cursor-subscription.js
+++ b/src/cursor-subscription.js
@@ -13,7 +13,7 @@ export class CursorSubscription {
   connect () {
     return new Promise((resolve, reject) => {
       this.hooks = { ...this.hooks, subscriptionEstablished: resolve }
-      this.instance.subscribeNonResuming({
+      this.sub = this.instance.subscribeNonResuming({
         path: this.path,
         listeners: {
           onError: reject,
@@ -21,6 +21,10 @@ export class CursorSubscription {
         }
       })
     })
+  }
+
+  cancel () {
+    this.sub && this.sub.unsubscribe()
   }
 
   onEvent = ({ body }) => {

--- a/src/message-subscription.js
+++ b/src/message-subscription.js
@@ -18,7 +18,7 @@ export class MessageSubscription {
 
   connect () {
     return new Promise((resolve, reject) => {
-      this.instance.subscribeNonResuming({
+      this.sub = this.instance.subscribeNonResuming({
         path: `/rooms/${this.roomId}?${urlEncode({
           message_limit: this.messageLimit
         })}`,
@@ -29,6 +29,10 @@ export class MessageSubscription {
         }
       })
     })
+  }
+
+  cancel () {
+    this.sub && this.sub.unsubscribe()
   }
 
   onEvent = ({ body }) => {

--- a/src/presence-subscription.js
+++ b/src/presence-subscription.js
@@ -25,7 +25,7 @@ export class PresenceSubscription {
   connect () {
     return new Promise((resolve, reject) => {
       this.hooks = { ...this.hooks, subscriptionEstablished: resolve }
-      this.instance.subscribeNonResuming({
+      this.sub = this.instance.subscribeNonResuming({
         path: `/users/${encodeURIComponent(this.userId)}/presence`,
         listeners: {
           onError: reject,
@@ -33,6 +33,10 @@ export class PresenceSubscription {
         }
       })
     })
+  }
+
+  cancel () {
+    this.sub && this.sub.unsubscribe()
   }
 
   onEvent = ({ body }) => {

--- a/src/room-subscription.js
+++ b/src/room-subscription.js
@@ -1,0 +1,13 @@
+export class RoomSubscription {
+  constructor ({ hooks, messageSub, cursorSub }) {
+    this.hooks = hooks
+    this.messageSub = messageSub
+    this.cursorSub = cursorSub
+  }
+
+  cancel () {
+    this.hooks = {}
+    this.messageSub.cancel()
+    this.cursorSub.cancel()
+  }
+}

--- a/src/user-subscription.js
+++ b/src/user-subscription.js
@@ -16,7 +16,7 @@ export class UserSubscription {
   connect () {
     return new Promise((resolve, reject) => {
       this.hooks = { ...this.hooks, subscriptionEstablished: resolve }
-      this.instance.subscribeNonResuming({
+      this.sub = this.instance.subscribeNonResuming({
         path: '/users',
         listeners: {
           onError: reject,
@@ -24,6 +24,10 @@ export class UserSubscription {
         }
       })
     })
+  }
+
+  cancel () {
+    this.sub && this.sub.unsubscribe()
   }
 
   onEvent = ({ body }) => {

--- a/tests/main.js
+++ b/tests/main.js
@@ -694,6 +694,22 @@ test('subscribe to room and receive sent messages', t => {
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
+test('unsubscribe from room', t => {
+  fetchUser(t, 'alice')
+    .then(alice => alice.subscribeToRoom(bobsRoom.id,
+      {
+        newMessage: once(m => {
+          endWithErr(t, 'should not be called after unsubscribe')
+        })
+      }, 0)
+      .then(() => alice.roomSubscriptions[bobsRoom.id].cancel())
+      .then(() => sendMessages(alice, bobsRoom, ['yoooo']))
+      .then(() => setTimeout(t.end, 1000))
+    )
+    .catch(endWithErr(t))
+  t.timeoutAfter(TEST_TIMEOUT)
+})
+
 // Attachments
 
 test('send message with malformed attachment fails', t => {


### PR DESCRIPTION
All subs can now be cancelled with `sub.cancel()`. e.g.

```
currentUser.roomSubscriptions[roomId].cancel()
```

corresponding docs update: https://github.com/pusher/mimir/pull/290/commits/b35eade9de4771ef66a6ab1fb1320c692ec284cd