### PR TITLE
Bump pusher-platform dependency to 0.15.0 and unskip previously skipped tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "git+https://github.com/pusher/chatkit-client-js.git"
   },
   "dependencies": {
-    "pusher-platform": "^0.14.0"
+    "pusher-platform": "^0.15.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/tests/main.js
+++ b/tests/main.js
@@ -220,6 +220,14 @@ test('[setup] create Alice', t => {
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
+// this shouldn't be necessary once the server-side bug is fixed such
+// that user deletion also leads to relevant user role deletion(s)
+test('[setup] assign default role to Alice', t => {
+  server.assignGlobalRoleToUser('alice', 'default')
+    .then(() => t.end())
+    .catch(endWithErr(t))
+})
+
 test('connection resolves with current user object', t => {
   fetchUser(t, 'alice')
     .then(alice => {
@@ -981,8 +989,7 @@ test(`get another user's read cursor after subscribing to a room`, t => {
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
-// FIXME platform request method should not resolve on failed requests
-test.skip('non-admin update room fails gracefully', t => {
+test('non-admin update room fails gracefully', t => {
   fetchUser(t, 'alice')
     .then(alice => alice.updateRoom(bobsRoom.id, {
       name: `Bob's updated room`
@@ -996,8 +1003,7 @@ test.skip('non-admin update room fails gracefully', t => {
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
-// FIXME platform request method should not resolve on failed requests
-test.skip('non-admin delete room fails gracefully', t => {
+test('non-admin delete room fails gracefully', t => {
   fetchUser(t, 'alice')
     .then(alice => alice.deleteRoom(bobsRoom.id))
     .then(() => t.end(`deleteRoom should not resolve`))

--- a/yarn.lock
+++ b/yarn.lock
@@ -3342,9 +3342,9 @@ pusher-platform-node@~0.11.1:
     jsonwebtoken "^7.4.1"
     request "^2.81.0"
 
-pusher-platform@^0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/pusher-platform/-/pusher-platform-0.14.0.tgz#81b410b51c4b1cc31e24d79295af8ef947c3c307"
+pusher-platform@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/pusher-platform/-/pusher-platform-0.15.0.tgz#d94c63ceeef5e05e5fc09504f3c7d0971cd218a3"
 
 qs@6.5.1, qs@~6.5.1:
   version "6.5.1"


### PR DESCRIPTION
See title