### PR TITLE
Vanilla auth context

### DIFF
--- a/src/user-store.js
+++ b/src/user-store.js
@@ -9,7 +9,7 @@ import {
   values
 } from 'ramda'
 
-import { appendQueryParam } from './utils'
+import { appendQueryParams } from './utils'
 import { Store } from './store'
 import { parseBasicUser } from './parsers'
 import { User } from './user'
@@ -63,7 +63,10 @@ export class UserStore {
     return this.instance
       .request({
         method: 'GET',
-        path: appendQueryParam('user_ids', join(',', missing), '/users_by_ids')
+        path: appendQueryParams(
+          { user_ids: join(',', missing) },
+          '/users_by_ids'
+        )
       })
       .then(pipe(
         JSON.parse,

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,7 +10,6 @@ import {
   toPairs
 } from 'ramda'
 
-// urlEncode :: Object -> String
 export const urlEncode = pipe(
   filter(x => x !== undefined),
   toPairs,
@@ -18,10 +17,9 @@ export const urlEncode = pipe(
   join('&')
 )
 
-// appendQueryParam :: String -> String -> String -> String
-export const appendQueryParam = (key, value, url) => {
+export const appendQueryParams = (queryParams, url) => {
   const separator = contains('?', url) ? '&' : '?'
-  return url + separator + urlEncode({ [key]: value })
+  return url + separator + urlEncode(queryParams)
 }
 
 export const extractQueryParams = url =>


### PR DESCRIPTION
Slightly changes the interface to put `queryParams` and `headers` as separate options in the root options object. Open to debate on this but not sure the extra nesting is really worth it?

```javascript
const tokenProvider = new TokenProvider({
  url: 'my-token-provider/token',
  queryParams: {
    custom: 'parameters'
  },
  headers: {
    custom: 'headers'
  }
})
```

corresponding mimir change: https://github.com/pusher/mimir/pull/290/commits/c4d095cc8133b6860096d7e3a27d91216acc11da