### PR TITLE
mutate existin objects on change so that references continue to point…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project adheres to [Semantic Versioning Scheme](http://semver.org)
 
 ## [Unreleased](https://github.com/pusher/chatkit-client-js/compare/0.7.0...HEAD)
 
+### Changes
+
+ - Subobjects of the current user (Rooms, Users, etc) are now mutated instead
+   of replaced, so any reference to a room will represent the up to date state
+   of that room.
+
 ## 0.7.0 -- 2018-03-13
 
 This version represents a radical departure from 0.6.X. The interface is very

--- a/src/room-store.js
+++ b/src/room-store.js
@@ -1,4 +1,4 @@
-import { append, map, mergeWith, filter, uniq, curry, pipe } from 'ramda'
+import { append, map, filter, uniq, curry, pipe } from 'ramda'
 
 import { Store } from './store'
 import { parseBasicRoom } from './parsers'
@@ -13,30 +13,23 @@ export class RoomStore {
 
   store = new Store()
 
-  initialize = this.store.initialize
+  initialize = initial => {
+    this.store.initialize(map(this.decorate, initial))
+  }
 
   set = curry((roomId, basicRoom) => {
-    return this.store.set(roomId, basicRoom)
-      .then(this.decorate)
+    return this.store.set(roomId, this.decorate(basicRoom))
       .then(room =>
         this.userStore.fetchMissingUsers(room.userIds).then(() => room)
       )
   })
 
-  get = roomId => this.store.get(roomId).then(basicRoom =>
-    basicRoom || this.fetchBasicRoom(roomId).then(this.set(roomId))
-  ).then(this.decorate)
-
-  pop = roomId => this.store.pop(roomId).then(basicRoom =>
-    basicRoom || this.fetchBasicRoom(roomId)
-  ).then(this.decorate)
-
-  addUserToRoom = (roomId, userId) => this.pop(roomId).then(r =>
-    this.set(roomId, { ...r, userIds: uniq(append(userId, r.userIds)) })
+  get = roomId => this.store.get(roomId).then(room =>
+    room || this.fetchBasicRoom(roomId).then(this.set(roomId))
   )
 
-  removeUserFromRoom = (roomId, userId) => this.pop(roomId).then(r =>
-    this.set(roomId, { ...r, userIds: filter(id => id !== userId, r.userIds) })
+  pop = roomId => this.store.pop(roomId).then(room =>
+    room || this.fetchBasicRoom(roomId).then(this.decorate)
   )
 
   update = (roomId, updates) => this.store.pop(roomId).then(r =>
@@ -55,9 +48,9 @@ export class RoomStore {
       })
   }
 
-  snapshot = () => map(this.decorate, this.store.snapshot())
+  snapshot = this.store.snapshot
 
-  getSync = roomId => this.decorate(this.store.getSync(roomId))
+  getSync = this.store.getSync
 
   decorate = basicRoom => {
     return basicRoom

--- a/src/room-store.js
+++ b/src/room-store.js
@@ -32,9 +32,27 @@ export class RoomStore {
     room || this.fetchBasicRoom(roomId).then(this.decorate)
   )
 
-  update = (roomId, updates) => this.store.pop(roomId).then(r =>
-    this.set(roomId, mergeWith((x, y) => y || x, r, updates))
-  )
+  addUserToRoom = (roomId, userId) => this.store.update(roomId, r => {
+    r.userIds = uniq(append(userId, r.userIds))
+    return r
+  })
+
+  removeUserFromRoom = (roomId, userId) => this.store.update(roomId, r => {
+    r.userIds = filter(id => id !== userId, r.userIds)
+    return r
+  })
+
+  update = (roomId, updates) => this.store.update(roomId, r => {
+    r.createdAt = updates.createdAt || r.createdAt
+    r.createdByUserId = updates.createdByUserId || r.createdByUserId
+    r.deletedAt = updates.deletedAt || r.deletedAt
+    r.id = updates.id || r.id
+    r.isPrivate = updates.isPrivate || r.isPrivate
+    r.name = updates.name || r.name
+    r.updatedAt = updates.updatedAt || r.updatedAt
+    r.userIds = updates.userIds || r.userIds
+    return r
+  })
 
   fetchBasicRoom = roomId => {
     return this.instance

--- a/src/store.js
+++ b/src/store.js
@@ -1,11 +1,11 @@
-import { clone, forEach } from 'ramda'
+import { forEach } from 'ramda'
 
 export class Store {
   pendingSets = [] // [{ key, value, resolve }]
   pendingGets = [] // [{ key, resolve }]
 
   initialize = initialStore => {
-    this.store = clone(initialStore)
+    this.store = initialStore
     forEach(({ key, value, resolve }) => {
       resolve(this.store[key] = value)
     }, this.pendingSets)
@@ -38,6 +38,8 @@ export class Store {
     delete this.store[key]
     return value
   })
+
+  update = (key, f) => this.get(key).then(value => this.set(key, f(value)))
 
   // snapshot and getSync are useful for building synchronous interfaces, but
   // should only be used when we can guarantee that the information we want is

--- a/src/user-store.js
+++ b/src/user-store.js
@@ -23,14 +23,16 @@ export class UserStore {
 
   store = new Store()
 
-  initialize = this.store.initialize
+  initialize = initial => {
+    this.store.initialize(map(this.decorate, initial))
+  }
 
-  set = this.store.set
+  set = (userId, basicUser) => this.store.set(userId, this.decorate(basicUser))
 
   get = userId => Promise.all([
     this.store.get(userId).then(user => user || this.fetchBasicUser(userId)),
     this.presenceStore.get(userId) // Make sure it's safe to getSync
-  ]).then(([user, presence]) => this.decorate(user))
+  ]).then(([user, _presence]) => user)
 
   fetchBasicUser = userId => {
     return this.instance
@@ -79,9 +81,9 @@ export class UserStore {
       })
   }
 
-  snapshot = () => map(this.decorate, this.store.snapshot())
+  snapshot = this.store.snapshot
 
-  getSync = userId => this.decorate(this.store.getSync(userId))
+  getSync = this.store.getSync
 
   decorate = basicUser => {
     return basicUser


### PR DESCRIPTION
… to up to date state (n.b. mutation is evil -_-)

So you can go

    const myRoom = currentUser.rooms.find(isMyRoom)

and then if, for example, the users in a room changes, later, `myRoom` will change too.

Some of the changes revolve around decorating objects in the store _on set_ instead of _on get_. This needs to happen because decorating an object necessarily changes its reference.