### PR TITLE
don't fetch on pop if we don't have a local copy of a room

### DIFF
--- a/src/room-store.js
+++ b/src/room-store.js
@@ -28,9 +28,7 @@ export class RoomStore {
     room || this.fetchBasicRoom(roomId).then(this.set(roomId))
   )
 
-  pop = roomId => this.store.pop(roomId).then(room =>
-    room || this.fetchBasicRoom(roomId).then(this.decorate)
-  )
+  pop = this.store.pop
 
   addUserToRoom = (roomId, userId) => this.store.update(roomId, r => {
     r.userIds = uniq(append(userId, r.userIds))


### PR DESCRIPTION
If we're popping a room from the store, then we don't want it anyway, so there's no sense in fetching it.

This was the cause of `room_membership_required` errors when leaving a room.

- `leaveRoom` pops the room from the store
- the `removed_from_room` event is received and causes a second pop of the same room
- this room is no longer in the store, so we try to fetch it (we shouldn't bother)
- the API returns a 401 because we no longer have permission to get info about the room (since we're not a member of it any more)