### PR TITLE
don't cast private in updateRoom options, since we don't want undefin…

### DIFF
--- a/src/current-user.js
+++ b/src/current-user.js
@@ -352,12 +352,13 @@ export class CurrentUser {
   updateRoom = ({ roomId, name, ...rest } = {}) => {
     typeCheck('roomId', 'number', roomId)
     name && typeCheck('name', 'string', name)
+    rest.private && typeCheck('private', 'boolean', rest.private)
     return this.apiInstance.request({
       method: 'PUT',
       path: `/rooms/${roomId}`,
       json: {
-        name: name,
-        private: !!rest.private // private is a reserved word in strict mode!
+        name,
+        private: rest.private // private is a reserved word in strict mode!
       }
     })
       .then(() => {})


### PR DESCRIPTION
…ed to become false (and risk accidentally making private rooms public when just trying to change the name)