### PR TITLE
sensible default for missing presence in user's presence property

### DIFF
--- a/src/user.js
+++ b/src/user.js
@@ -10,6 +10,10 @@ export class User {
   }
 
   get presence () {
-    return this.presenceStore.getSync(this.id)
+    return this.presenceStore.getSync(this.id) || {
+      lastSeenAt: undefined,
+      state: 'unknown',
+      userId: this.id
+    }
   }
 }


### PR DESCRIPTION
Makes the object consistent so that consumers don't have to check for undefined. It would be nice if we always had the appropriate data from the API, but this is a "better than nothing" fix in the meantime.