### PR TITLE
pending release of pusher-platform-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "rollup-plugin-alias": "^1.4.0",
     "rollup-plugin-babel": "^3.0.3",
     "rollup-plugin-commonjs": "^8.3.0",
+    "rollup-plugin-json": "^2.3.0",
     "rollup-plugin-node-resolve": "^3.0.2",
     "rollup-plugin-uglify": "^3.0.0",
     "snazzy": "^7.0.0",

--- a/rollup/shared.js
+++ b/rollup/shared.js
@@ -2,6 +2,7 @@ import babel from 'rollup-plugin-babel'
 import commonjs from 'rollup-plugin-commonjs'
 import resolve from 'rollup-plugin-node-resolve'
 import uglify from 'rollup-plugin-uglify'
+import json from 'rollup-plugin-json'
 
 const pusherPlatformExports = [
   'BaseClient',
@@ -13,6 +14,7 @@ const pusherPlatformExports = [
 export default {
   input: 'src/main.js',
   plugins: [
+    json(),
     babel({
       presets: [
         [

--- a/src/chat-manager.js
+++ b/src/chat-manager.js
@@ -4,6 +4,8 @@ import { split } from 'ramda'
 import { CurrentUser } from './current-user'
 import { typeCheck, typeCheckObj } from './utils'
 
+import { version } from '../package.json'
+
 export class ChatManager {
   constructor ({ instanceLocator, tokenProvider, userId, ...options } = {}) {
     typeCheck('instanceLocator', 'string', instanceLocator)
@@ -18,7 +20,9 @@ export class ChatManager {
     }
     const baseClient = options.baseClient || new BaseClient({
       host: `${cluster}.${HOST_BASE}`,
-      logger: options.logger
+      logger: options.logger,
+      sdkProduct: 'chatkit',
+      sdkVersion: version
     })
     if (typeof tokenProvider.setUserId === 'function') {
       tokenProvider.setUserId(userId)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3702,6 +3702,12 @@ rollup-plugin-commonjs@^8.3.0:
     resolve "^1.4.0"
     rollup-pluginutils "^2.0.1"
 
+rollup-plugin-json@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-json/-/rollup-plugin-json-2.3.0.tgz#3c07a452c1b5391be28006fbfff3644056ce0add"
+  dependencies:
+    rollup-pluginutils "^2.0.1"
+
 rollup-plugin-node-resolve@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.0.2.tgz#38babc12fd404cc2ba1ff68648fe43fa3ffee6b0"


### PR DESCRIPTION
This still needs a bump of the version of `pusher-platform-js` when https://github.com/pusher/pusher-platform-js/pull/88 is released.