### PR TITLE
track ongoing user info requests so we don't make redundant requests

### DIFF
--- a/src/token-provider.js
+++ b/src/token-provider.js
@@ -34,11 +34,11 @@ export class TokenProvider {
     })
       .then(res => {
         const { access_token: token, expires_in: expiresIn } = JSON.parse(res)
-        this.req = undefined
+        delete this.req
         return { token, expiresIn }
       })
       .catch(err => {
-        this.req = undefined
+        delete this.req
         throw err
       })
     return this.req


### PR DESCRIPTION
- always use the batch endpoint
- keep references to ongoing requests
- only make new requests for user IDs that don't already have an ongoing request