### PR TITLE
Api v2 membership subscriptions

### DIFF
--- a/src/chat-manager.js
+++ b/src/chat-manager.js
@@ -68,6 +68,7 @@ export class ChatManager {
     })
     return Promise.all([
       currentUser.establishUserSubscription(),
+      currentUser.establishMembershipSubscriptions(),
       currentUser.establishPresenceSubscription(),
       currentUser.establishCursorSubscription()
     ]).then(() => currentUser)

--- a/src/current-user.js
+++ b/src/current-user.js
@@ -194,6 +194,7 @@ export class CurrentUser {
         const basicRoom = parseBasicRoom(JSON.parse(res))
         return this.roomStore.set(basicRoom.id, basicRoom)
       })
+      .then(room => this.addMembershipSubscription(roomId).then(() => room))
       .catch(err => {
         this.logger.warn(`error joining room ${roomId}:`, err)
         throw err
@@ -207,6 +208,7 @@ export class CurrentUser {
         method: 'POST',
         path: `/users/${this.encodedId}/rooms/${roomId}/leave`
       })
+      .then(() => this.removeMembershipSubscription(roomId))
       .then(() => this.roomStore.pop(roomId))
       .catch(err => {
         this.logger.warn(`error leaving room ${roomId}:`, err)

--- a/src/current-user.js
+++ b/src/current-user.js
@@ -545,6 +545,7 @@ export class CurrentUser {
       this.membershipSubscriptions[roomId].cancel()
       delete this.membershipSubscriptions[roomId]
     }
+    return Promise.resolve()
   }
 }
 

--- a/src/membership-subscription.js
+++ b/src/membership-subscription.js
@@ -1,0 +1,83 @@
+export class MembershipSubscription {
+  constructor (options) {
+    this.roomId = options.roomId
+    this.hooks = options.hooks
+    this.instance = options.instance
+    this.userStore = options.userStore
+    this.roomStore = options.roomStore
+    this.logger = options.logger
+  }
+
+  connect () {
+    return new Promise((resolve, reject) => {
+      this.onSubscriptionEstablished = resolve
+      this.sub = this.instance.subscribeNonResuming({
+        path: `/rooms/${this.roomId}/memberships`,
+        listeners: {
+          onError: reject,
+          onEvent: this.onEvent
+        }
+      })
+    })
+  }
+
+  cancel () {
+    try {
+      this.sub && this.sub.unsubscribe()
+    } catch (err) {
+      this.logger.debug('error when cancelling membership subscription', err)
+    }
+  }
+
+  onEvent = ({ body }) => {
+    switch (body.event_name) {
+      case 'initial_state':
+        this.onInitialState(body.data)
+        break
+      case 'user_joined':
+        this.onUserJoined(body.data)
+        break
+      case 'user_left':
+        this.onUserLeft(body.data)
+        break
+    }
+  }
+
+  onInitialState = ({ user_ids: userIds }) => {
+    this.roomStore
+      .update(this.roomId, { userIds })
+      .then(this.onSubscriptionEstablished)
+  }
+
+  onUserJoined = ({ user_id: userId }) => {
+    this.roomStore.addUserToRoom(this.roomId, userId).then(room => {
+      this.userStore.get(userId).then(user => {
+        if (this.hooks.global.onUserJoinedRoom) {
+          this.hooks.global.onUserJoinedRoom(room, user)
+        }
+        if (
+          this.hooks.rooms[this.roomId] &&
+          this.hooks.rooms[this.roomId].onUserJoined
+        ) {
+          this.hooks.rooms[this.roomId].onUserJoined(user)
+        }
+      })
+    })
+  }
+
+  onUserLeft = ({ user_id: userId }) => {
+    this.roomStore.removeUserFromRoom(this.roomId, userId).then(room => {
+      this.userStore.get(userId).then(user => {
+        if (this.hooks.global.onUserLeftRoom) {
+          this.hooks.global.onUserLeftRoom(room, user)
+        }
+        if (
+          this.hooks.rooms[this.roomId] &&
+          this.hooks.rooms[this.roomId].onUserLeft
+        ) {
+          this.hooks.rooms[this.roomId].onUserLeft(user)
+        }
+      })
+    })
+  }
+}

--- a/src/parsers.js
+++ b/src/parsers.js
@@ -9,8 +9,7 @@ export const parseBasicRoom = data => ({
   id: data.id,
   isPrivate: data.private,
   name: data.name,
-  updatedAt: data.updated_at,
-  userIds: data.member_user_ids
+  updatedAt: data.updated_at
 })
 
 export const parseBasicUser = data => ({

--- a/src/room.js
+++ b/src/room.js
@@ -9,7 +9,7 @@ export class Room {
     this.isPrivate = basicRoom.isPrivate
     this.name = basicRoom.name
     this.updatedAt = basicRoom.updatedAt
-    this.userIds = basicRoom.userIds
+    this.userIds = []
     this.userStore = userStore
   }
 

--- a/src/user-subscription.js
+++ b/src/user-subscription.js
@@ -74,11 +74,12 @@ export class UserSubscription {
 
   onRemovedFromRoom = ({ room_id: roomId }) => {
     this.roomStore.pop(roomId).then(room => {
-      // room will be undefined if we left with leaveRoom
-      this.hooks.internal.onRemovedFromRoom(roomId)
-      if (room && this.hooks.global.onRemovedFromRoom) {
-        this.hooks.global.onRemovedFromRoom(room)
-      }
+      this.hooks.internal.onRemovedFromRoom(roomId).then(() => {
+        // room will be undefined if we left with leaveRoom
+        if (room && this.hooks.global.onRemovedFromRoom) {
+          this.hooks.global.onRemovedFromRoom(room)
+        }
+      })
     })
   }
 

--- a/src/user-subscription.js
+++ b/src/user-subscription.js
@@ -64,15 +64,18 @@ export class UserSubscription {
   onAddedToRoom = ({ room: roomData }) => {
     const basicRoom = parseBasicRoom(roomData)
     this.roomStore.set(basicRoom.id, basicRoom).then(room => {
-      if (this.hooks.global.onAddedToRoom) {
-        this.hooks.global.onAddedToRoom(room)
-      }
+      this.hooks.internal.onAddedToRoom(basicRoom.id).then(() => {
+        if (this.hooks.global.onAddedToRoom) {
+          this.hooks.global.onAddedToRoom(room)
+        }
+      })
     })
   }
 
   onRemovedFromRoom = ({ room_id: roomId }) => {
     this.roomStore.pop(roomId).then(room => {
       // room will be undefined if we left with leaveRoom
+      this.hooks.internal.onRemovedFromRoom(roomId)
       if (room && this.hooks.global.onRemovedFromRoom) {
         this.hooks.global.onRemovedFromRoom(room)
       }

--- a/src/user-subscription.js
+++ b/src/user-subscription.js
@@ -45,12 +45,6 @@ export class UserSubscription {
       case 'removed_from_room':
         this.onRemovedFromRoom(body.data)
         break
-      case 'user_joined':
-        this.onUserJoined(body.data)
-        break
-      case 'user_left':
-        this.onUserLeft(body.data)
-        break
       case 'room_updated':
         this.onRoomUpdated(body.data)
         break
@@ -82,38 +76,6 @@ export class UserSubscription {
       if (room && this.hooks.global.onRemovedFromRoom) {
         this.hooks.global.onRemovedFromRoom(room)
       }
-    })
-  }
-
-  onUserJoined = ({ room_id: roomId, user_id: userId }) => {
-    this.roomStore.addUserToRoom(roomId, userId).then(room => {
-      this.userStore.get(userId).then(user => {
-        if (this.hooks.global.onUserJoinedRoom) {
-          this.hooks.global.onUserJoinedRoom(room, user)
-        }
-        if (
-          this.hooks.rooms[roomId] &&
-          this.hooks.rooms[roomId].onUserJoined
-        ) {
-          this.hooks.rooms[roomId].onUserJoined(user)
-        }
-      })
-    })
-  }
-
-  onUserLeft = ({ room_id: roomId, user_id: userId }) => {
-    this.roomStore.removeUserFromRoom(roomId, userId).then(room => {
-      this.userStore.get(userId).then(user => {
-        if (this.hooks.global.onUserLeftRoom) {
-          this.hooks.global.onUserLeftRoom(room, user)
-        }
-        if (
-          this.hooks.rooms[roomId] &&
-          this.hooks.rooms[roomId].onUserLeft
-        ) {
-          this.hooks.rooms[roomId].onUserLeft(user)
-        }
-      })
     })
   }
 


### PR DESCRIPTION
Create membership subscriptions to handle member joined and left events.

- subscribes to the membership sub for every room on connection (before initializing user store, so we can still use the initial membership data to pre-fetch user info)
- subscribes to the membership sub for new rooms as they are joined (or you're added)
- unsubscribes from membership subs when rooms are left (or you're removed)