### PR TITLE
don't fire onIsTyping for the user's own typing indicators

### DIFF
--- a/src/current-user.js
+++ b/src/current-user.js
@@ -83,7 +83,6 @@ export class CurrentUser {
     })
     this.typingIndicators = new TypingIndicators({
       hooks: this.hooks,
-      userId: this.id,
       instance: this.apiInstance,
       logger: this.logger
     })

--- a/src/message-subscription.js
+++ b/src/message-subscription.js
@@ -85,7 +85,9 @@ export class MessageSubscription {
   }
 
   onIsTyping = ({ user_id: userId }) => {
-    Promise.all([this.roomStore.get(this.roomId), this.userStore.get(userId)])
-      .then(([room, user]) => this.typingIndicators.onIsTyping(room, user))
+    if (userId !== this.userId) {
+      Promise.all([this.roomStore.get(this.roomId), this.userStore.get(userId)])
+        .then(([room, user]) => this.typingIndicators.onIsTyping(room, user))
+    }
   }
 }

--- a/src/typing-indicators.js
+++ b/src/typing-indicators.js
@@ -1,9 +1,8 @@
 import { TYPING_INDICATOR_TTL, TYPING_INDICATOR_LEEWAY } from './constants'
 
 export class TypingIndicators {
-  constructor ({ hooks, userId, instance, logger }) {
+  constructor ({ hooks, instance, logger }) {
     this.hooks = hooks
-    this.userId = userId
     this.instance = instance
     this.logger = logger
     this.lastSentRequests = {}


### PR DESCRIPTION
In `v2` the server won't be filtering out the connected user's own typing indicators, so we need to filter them client side. This is a trivial check against the ID.