### PR TITLE
timeout subscriptions after 5s

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,4 @@
 export const TYPING_INDICATOR_TTL = 1500
 export const TYPING_INDICATOR_LEEWAY = 500
 export const SET_CURSOR_WAIT = 500
+export const SUBSCRIPTION_TIMEOUT = 5000

--- a/src/current-user.js
+++ b/src/current-user.js
@@ -469,7 +469,7 @@ export class CurrentUser {
     })
     return this.presenceSubscription.connect()
       .catch(err => {
-        this.logger.warn('error establishing presence subscription:', err)
+        this.logger.error('error establishing presence subscription:', err)
         throw err
       })
   }
@@ -492,7 +492,7 @@ export class CurrentUser {
     return this.cursorSubscription.connect()
       .then(() => this.cursorStore.initialize({}))
       .catch(err => {
-        this.logger.warn('error establishing cursor subscription:', err)
+        this.logger.error('error establishing cursor subscription:', err)
         throw err
       })
   }


### PR DESCRIPTION
All subscriptions that we expect an `initial_state` event from will time out with an error after 5s. In particular this means the initial connection no longer hangs forever if one of the services is broken (like used to happen with presence).