### PR TITLE
Add disconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This project adheres to [Semantic Versioning Scheme](http://semver.org)
 
 ---
 
+## 0.7.14 -- 2018-06-12
+
+## Changes
+
+- Adds a `disconnect` method to `ChatManager` which disconnects a user from Chatkit.
+
 ## 0.7.13 -- 2018-06-12
 
 ## Changes

--- a/src/chat-manager.js
+++ b/src/chat-manager.js
@@ -70,6 +70,11 @@ export class ChatManager {
       currentUser.establishUserSubscription(),
       currentUser.establishPresenceSubscription(),
       currentUser.establishCursorSubscription()
-    ]).then(() => currentUser)
+    ]).then(() => {
+      this.currentUser = currentUser
+      return currentUser
+    })
   }
+
+  disconnect = () => { if (this.currentUser) this.currentUser.disconnect() }
 }

--- a/src/current-user.js
+++ b/src/current-user.js
@@ -6,6 +6,7 @@ import {
   has,
   indexBy,
   map,
+  forEachObjIndexed,
   max,
   pipe,
   prop,
@@ -505,6 +506,13 @@ export class CurrentUser {
         this.logger.warn('error fetching initial user information:', err)
       })
       .then(() => this.userStore.initialize({}))
+  }
+
+  disconnect = () => {
+    this.userSubscription.cancel()
+    this.presenceSubscription.cancel()
+    this.cursorSubscription.cancel()
+    forEachObjIndexed(sub => sub.cancel(), this.roomSubscriptions)
   }
 }
 

--- a/tests/main.js
+++ b/tests/main.js
@@ -89,12 +89,7 @@ const sendMessages = (user, room, texts) => length(texts) === 0
 // Teardown first so that we can kill the tests at any time, safe in the
 // knowledge that we'll always be starting with a blank slate next time
 
-const teardown = currentUser => {
-  currentUser.userSubscription.cancel()
-  currentUser.presenceSubscription.cancel()
-  currentUser.cursorSubscription.cancel()
-  map(sub => sub.cancel(), currentUser.roomSubscriptions)
-}
+const teardown = currentUser => currentUser.disconnect()
 
 test('[teardown]', t => {
   server.apiRequest({


### PR DESCRIPTION
This PR adds a `disconnect` method to the `ChatManager` class to allow for easy disconnection from Chatkit. It cancels all subscriptions on the `CurrentUser` object.