### PR TITLE
get room first when calling leaveRoom so that it isn't removed in the…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This project adheres to [Semantic Versioning Scheme](http://semver.org)
 
 ## [Unreleased](https://github.com/pusher/chatkit-client-js/compare/0.7.16...HEAD)
 
+### Changes
+
+- Internal fix to ensure that the room is properly returned from `leaveRoom`.
+  No external change.
+
 ## [0.7.16](https://github.com/pusher/chatkit-client-js/compare/0.7.14...0.7.16) - 2018-06-18
 
 ### Additions

--- a/src/current-user.js
+++ b/src/current-user.js
@@ -199,12 +199,13 @@ export class CurrentUser {
 
   leaveRoom = ({ roomId } = {}) => {
     typeCheck('roomId', 'number', roomId)
-    return this.apiInstance
-      .request({
+    return this.roomStore.get(roomId)
+      .then(room => this.apiInstance.request({
         method: 'POST',
         path: `/users/${this.encodedId}/rooms/${roomId}/leave`
       })
-      .then(() => this.roomStore.pop(roomId))
+        .then(() => this.roomStore.pop(roomId))
+        .then(() => room))
       .catch(err => {
         this.logger.warn(`error leaving room ${roomId}:`, err)
         throw err

--- a/tests/main.js
+++ b/tests/main.js
@@ -682,7 +682,8 @@ test(`leave room [Bob leaves Alice's room]`, t => {
         `should include Bob's room`
       )
       bob.leaveRoom({ roomId: alicesRoom.id })
-        .then(() => {
+        .then(room => {
+          t.equal(room.id, alicesRoom.id)
           t.false(
             any(r => r.id === alicesRoom.id, bob.rooms),
             `shouldn't include Alice's room`


### PR DESCRIPTION
… interim

Should mitigate a race condition where the `removed_from_room` event can be received before popping the room from the store at the end of the `leaveRoom` method, resulting in returning `undefined`.