### PR TITLE
onMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning Scheme](http://semver.org)
 
 ### Changes
 
+- renames `onNewMessage` to `onMessage`
+
 - `onPresenceChanged` replaces `onUserCameOnline` and `onUserWentOffline`.
   Takes parameters `(state, user)` -- where `state` is `{ current, previous }`
   and `current` and `previous` are one of `"online"`, `"offline"`, or

--- a/example/main.js
+++ b/example/main.js
@@ -50,7 +50,7 @@ chatManager.connect({
       currentUser.subscribeToRoom({
         roomId: roomToSubscribeTo.id,
         hooks: {
-          onNewMessage: message => {
+          onMessage: message => {
             console.log('new message:', message)
             const messagesList = document.getElementById('messages')
             const messageItem = document.createElement('li')

--- a/src/message-subscription.js
+++ b/src/message-subscription.js
@@ -55,7 +55,7 @@ export class MessageSubscription {
   onEvent = ({ body }) => {
     switch (body.event_name) {
       case 'new_message':
-        this.onNewMessage(body.data)
+        this.onMessage(body.data)
         break
       case 'is_typing':
         this.onIsTyping(body.data)
@@ -63,7 +63,7 @@ export class MessageSubscription {
     }
   }
 
-  onNewMessage = data => {
+  onMessage = data => {
     const pending = {
       message: new Message(
         parseBasicMessage(data),
@@ -88,9 +88,9 @@ export class MessageSubscription {
       const message = this.messageBuffer.shift().message
       if (
         this.hooks.rooms[this.roomId] &&
-        this.hooks.rooms[this.roomId].onNewMessage
+        this.hooks.rooms[this.roomId].onMessage
       ) {
-        this.hooks.rooms[this.roomId].onNewMessage(message)
+        this.hooks.rooms[this.roomId].onMessage(message)
       }
     }
   }

--- a/tests/main.js
+++ b/tests/main.js
@@ -797,7 +797,7 @@ test('subscribe to room and fetch initial messages', t => {
     .then(alice => alice.subscribeToRoom({
       roomId: bobsRoom.id,
       hooks: {
-        onNewMessage: concatBatch(4, messages => {
+        onMessage: concatBatch(4, messages => {
           t.deepEqual(map(m => m.text, messages), ['hello', 'hey', 'hi', 'ho'])
           t.equal(messages[0].sender.name, 'Alice')
           t.equal(messages[0].room.name, `Bob's new room`)
@@ -815,7 +815,7 @@ test('subscribe to room and fetch last two message only', t => {
     .then(alice => alice.subscribeToRoom({
       roomId: bobsRoom.id,
       hooks: {
-        onNewMessage: concatBatch(2, messages => {
+        onMessage: concatBatch(2, messages => {
           t.deepEqual(map(m => m.text, messages), ['hi', 'ho'])
           alice.disconnect()
           t.end()
@@ -832,7 +832,7 @@ test('subscribe to room and receive sent messages', t => {
     .then(alice => alice.subscribeToRoom({
       roomId: bobsRoom.id,
       hooks: {
-        onNewMessage: concatBatch(3, messages => {
+        onMessage: concatBatch(3, messages => {
           t.deepEqual(map(m => m.text, messages), ['yo', 'yoo', 'yooo'])
           t.equal(messages[0].sender.name, 'Alice')
           t.equal(messages[0].room.name, `Bob's new room`)
@@ -852,7 +852,7 @@ test('unsubscribe from room', t => {
     .then(alice => alice.subscribeToRoom({
       roomId: bobsRoom.id,
       hooks: {
-        onNewMessage: m => {
+        onMessage: m => {
           endWithErr(t, 'should not be called after unsubscribe')
         }
       },


### PR DESCRIPTION
Addresses the complaint that `onNewMessage` is fired with historical messages too, not only new ones.

Mimir change: https://github.com/pusher/mimir/pull/459