### PR TITLE
Tooling housekeeping

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,9 @@
-test/
-yarn-error.log
+# This file is written to be a whitelist instead of a blacklist. Start by
+# ignoring everything, then add back the files we want to be included in the
+# final NPM package.
+*
+
+# And these are the files that are allowed.
+!/LICENSE.md
+!/package.json
+!/dist/**/*

--- a/.publishrc
+++ b/.publishrc
@@ -1,0 +1,15 @@
+{
+  "validations": {
+    "vulnerableDependencies": true,
+    "uncommittedChanges": true,
+    "untrackedFiles": true,
+    "sensitiveData": false,
+    "branch": "master",
+    "gitTag": true
+  },
+  "confirm": true,
+  "publishCommand": "npm publish",
+  "publishTag": "latest",
+  "prePublishScript": "yarn lint:build:test",
+  "postPublishScript": false
+}

--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ For more information on the Chatkit service, [see here](https://pusher.com/chatk
 $ yarn add @pusher/chatkit-client
 ```
 
+[npm](https://www.npmjs.com/):
+
+```sh
+$ npm install @pusher/chatkit-server --save
+```
+
 ## Getting started
 
 Head over to [our documentation](https://docs.pusher.com/chatkit/reference/javascript).
+
+## Publishing
+
+Running `npm run publish-please` will walk you through the publishing steps.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ yarn add @pusher/chatkit-client
 [npm](https://www.npmjs.com/):
 
 ```sh
-$ npm install @pusher/chatkit-server --save
+$ npm install @pusher/chatkit-client --save
 ```
 
 ## Getting started

--- a/example/main.js
+++ b/example/main.js
@@ -1,12 +1,12 @@
-const INSTANCE_LOCATOR = 'YOUR_INSTANCE_LOCATOR'
-const TOKEN_PROVIDER_URL = 'YOUR_TOKEN_PROVIDER_URL'
-const USER_ID = 'YOUR_USER_ID'
+const INSTANCE_LOCATOR = "YOUR_INSTANCE_LOCATOR"
+const TOKEN_PROVIDER_URL = "YOUR_TOKEN_PROVIDER_URL"
+const USER_ID = "YOUR_USER_ID"
 
 let currentUser
 let room
 
 const tokenProvider = new Chatkit.TokenProvider({
-  url: TOKEN_PROVIDER_URL
+  url: TOKEN_PROVIDER_URL,
 })
 
 const chatManager = new Chatkit.ChatManager({
@@ -18,27 +18,28 @@ const chatManager = new Chatkit.ChatManager({
     warn: console.log,
     error: console.log,
     debug: console.log,
-    verbose: console.log
-  }
+    verbose: console.log,
+  },
 })
 
-chatManager.connect({
-  onAddedToRoom: room => {
-    console.log('added to room: ', room)
-  },
-  onRemovedFromRoom: room => {
-    console.log('removed from room: ', room)
-  },
-  onUserJoinedRoom: (room, user) => {
-    console.log('user: ', user, ' joined room: ', room)
-  },
-  onUserLeftRoom: (room, user) => {
-    console.log('user: ', user, ' left room: ', room)
-  },
-  onPresenceChanged: ({ previous, current }, user) => {
-    console.log('user: ', user, ' was ', previous, ' but is now ', current)
-  }
-})
+chatManager
+  .connect({
+    onAddedToRoom: room => {
+      console.log("added to room: ", room)
+    },
+    onRemovedFromRoom: room => {
+      console.log("removed from room: ", room)
+    },
+    onUserJoinedRoom: (room, user) => {
+      console.log("user: ", user, " joined room: ", room)
+    },
+    onUserLeftRoom: (room, user) => {
+      console.log("user: ", user, " left room: ", room)
+    },
+    onPresenceChanged: ({ previous, current }, user) => {
+      console.log("user: ", user, " was ", previous, " but is now ", current)
+    },
+  })
   .then(cUser => {
     currentUser = cUser
     window.currentUser = cUser
@@ -46,84 +47,88 @@ chatManager.connect({
 
     if (roomToSubscribeTo) {
       room = roomToSubscribeTo
-      console.log('Going to subscribe to', roomToSubscribeTo)
+      console.log("Going to subscribe to", roomToSubscribeTo)
       currentUser.subscribeToRoom({
         roomId: roomToSubscribeTo.id,
         hooks: {
           onMessage: message => {
-            console.log('new message:', message)
-            const messagesList = document.getElementById('messages')
-            const messageItem = document.createElement('li')
-            messageItem.className = 'message'
+            console.log("new message:", message)
+            const messagesList = document.getElementById("messages")
+            const messageItem = document.createElement("li")
+            messageItem.className = "message"
             messagesList.append(messageItem)
-            const textDiv = document.createElement('div')
+            const textDiv = document.createElement("div")
             textDiv.innerHTML = `${message.sender.name}: ${message.text}`
             messageItem.appendChild(textDiv)
 
             if (message.attachment) {
               let attachment
               switch (message.attachment.type) {
-                case 'image':
-                  attachment = document.createElement('img')
+                case "image":
+                  attachment = document.createElement("img")
                   break
-                case 'video':
-                  attachment = document.createElement('video')
-                  attachment.controls = 'controls'
+                case "video":
+                  attachment = document.createElement("video")
+                  attachment.controls = "controls"
                   break
-                case 'audio':
-                  attachment = document.createElement('audio')
-                  attachment.controls = 'controls'
+                case "audio":
+                  attachment = document.createElement("audio")
+                  attachment.controls = "controls"
                   break
                 default:
                   break
               }
 
-              attachment.className += ' attachment'
-              attachment.width = '400'
+              attachment.className += " attachment"
+              attachment.width = "400"
               attachment.src = message.attachment.link
               messageItem.appendChild(attachment)
             }
-          }
-        }
+          },
+        },
       })
     } else {
-      console.log('No room to subscribe to')
+      console.log("No room to subscribe to")
     }
-    console.log('Successful connection', currentUser)
+    console.log("Successful connection", currentUser)
   })
   .catch(err => {
-    console.log('Error on connection: ', err)
+    console.log("Error on connection: ", err)
   })
 
-document.getElementById('send-button').addEventListener('click', ev => {
-  const fileInput = document.querySelector('input[name=testfile]')
-  const textInput = document.getElementById('text-input')
+document.getElementById("send-button").addEventListener("click", ev => {
+  const fileInput = document.querySelector("input[name=testfile]")
+  const textInput = document.getElementById("text-input")
 
-  currentUser.sendMessage({
-    text: textInput.value,
-    roomId: room.id,
-    // attachment: {
-    //   link: 'https://assets.zeit.co/image/upload/front/api/deployment-state.png',
-    //   type: 'image',
-    // },
-    attachment: fileInput.value
-      ? {
-        file: fileInput.files[0],
-        // Split on slashes, remove whitespace
-        name: fileInput.value.split(/(\\|\/)/g).pop().replace(/\s+/g, ''),
-      }
-      : undefined,
-  })
+  currentUser
+    .sendMessage({
+      text: textInput.value,
+      roomId: room.id,
+      // attachment: {
+      //   link: 'https://assets.zeit.co/image/upload/front/api/deployment-state.png',
+      //   type: 'image',
+      // },
+      attachment: fileInput.value
+        ? {
+            file: fileInput.files[0],
+            // Split on slashes, remove whitespace
+            name: fileInput.value
+              .split(/(\\|\/)/g)
+              .pop()
+              .replace(/\s+/g, ""),
+          }
+        : undefined,
+    })
     .then(messageId => {
-      console.log('Success!', messageId)
-      fileInput.value = ''
-      textInput.value = ''
+      console.log("Success!", messageId)
+      fileInput.value = ""
+      textInput.value = ""
     })
     .catch(error => {
-      console.log('Error', error)
+      console.log("Error", error)
     })
 })
 
-document.querySelector('.choose-file').addEventListener('click', () => {
-  document.querySelector('input[name=testfile]').click()
+document.querySelector(".choose-file").addEventListener("click", () => {
+  document.querySelector("input[name=testfile]").click()
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pusher/chatkit-client",
-  "description": "Pusher Chatkit client library for browsers and react native",
+  "description": "Pusher Chatkit client SDK for browsers and react native",
   "main": "dist/web/chatkit.js",
   "version": "1.0.2",
   "author": "Pusher",
@@ -52,7 +52,9 @@
     "test:chrome": "browserify tests/main.js -t [ babelify --presets env --plugins transform-object-rest-spread ] | tape-run --render=tap-colorize -b chrome",
     "lint:build": "clear && yarn lint && clear && yarn build",
     "lint:build:test": "yarn lint:build && clear && yarn test",
-    "lint:build:test:chrome": "yarn lint:build && clear && yarn test:chrome"
+    "lint:build:test:chrome": "yarn lint:build && clear && yarn test:chrome",
+    "publish-please": "publish-please",
+    "prepublishOnly": "publish-please guard"
   },
   "prettier": {
     "semi": false,

--- a/package.json
+++ b/package.json
@@ -21,13 +21,15 @@
     "@pusher/chatkit-server": "0.13.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
-    "babel-eslint": "^7.0.0",
     "babel-plugin-external-helpers": "^6.22.0",
-    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "babelify": "^8.0.0",
     "browserify": "^15.2.0",
+    "eslint": "^5.8.0",
+    "eslint-config-prettier": "^3.1.0",
+    "eslint-plugin-prettier": "^3.0.0",
+    "prettier": "1.14.3",
     "rollup": "^0.55.3",
     "rollup-plugin-alias": "^1.4.0",
     "rollup-plugin-babel": "^3.0.3",
@@ -36,13 +38,13 @@
     "rollup-plugin-node-resolve": "^3.0.2",
     "rollup-plugin-uglify": "^3.0.0",
     "snazzy": "^7.0.0",
-    "standard": "^10.0.3",
     "tap-colorize": "^1.2.0",
     "tape": "^4.8.0",
     "tape-run": "^3.0.2"
   },
   "scripts": {
-    "lint": "standard --parser babel-eslint --verbose | snazzy",
+    "lint": "eslint src tests rollup",
+    "format": "prettier --write src/**/*.js tests/**/*.js rollup/**/*.js example/**/*.js",
     "build": "yarn build:web && yarn build:react-native",
     "build:web": "rollup -c rollup/web.js",
     "build:react-native": "rollup -c rollup/react-native.js",
@@ -50,7 +52,28 @@
     "lint:build": "clear && yarn lint && clear && yarn build",
     "lint:build:test": "yarn lint:build && clear && yarn test"
   },
-  "standard": {
-    "ignore": "example"
+  "prettier": {
+    "semi": false,
+    "trailingComma": "all"
+  },
+  "eslintConfig": {
+    "extends": [
+      "prettier",
+      "eslint:recommended"
+    ],
+    "plugins": [
+      "prettier"
+    ],
+    "rules": {
+      "prettier/prettier": "error"
+    },
+    "parserOptions": {
+      "sourceType": "module",
+      "ecmaVersion": 2018
+    },
+    "env": {
+      "browser": true,
+      "es6": true
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,8 +49,10 @@
     "build:web": "rollup -c rollup/web.js",
     "build:react-native": "rollup -c rollup/react-native.js",
     "test": "browserify tests/main.js -t [ babelify --presets env --plugins transform-object-rest-spread ] | tape-run --render=tap-colorize",
+    "test:chrome": "browserify tests/main.js -t [ babelify --presets env --plugins transform-object-rest-spread ] | tape-run --render=tap-colorize -b chrome",
     "lint:build": "clear && yarn lint && clear && yarn build",
-    "lint:build:test": "yarn lint:build && clear && yarn test"
+    "lint:build:test": "yarn lint:build && clear && yarn test",
+    "lint:build:test:chrome": "yarn lint:build && clear && yarn test:chrome"
   },
   "prettier": {
     "semi": false,

--- a/rollup/react-native.js
+++ b/rollup/react-native.js
@@ -1,21 +1,21 @@
-import { merge } from 'ramda'
-import alias from 'rollup-plugin-alias'
-import path from 'path'
+import { merge } from "ramda"
+import alias from "rollup-plugin-alias"
+import path from "path"
 
-import shared from './shared'
+import shared from "./shared"
 
 export default merge(shared, {
   output: {
-    file: 'dist/react-native/chatkit.js',
-    format: 'cjs',
-    name: 'Chatkit'
+    file: "dist/react-native/chatkit.js",
+    format: "cjs",
+    name: "Chatkit",
   },
   plugins: [
     alias({
-      'pusher-platform': path.resolve(
-        './node_modules/pusher-platform/react-native.js'
-      )
+      "pusher-platform": path.resolve(
+        "./node_modules/pusher-platform/react-native.js",
+      ),
     }),
-    ...shared.plugins
-  ]
+    ...shared.plugins,
+  ],
 })

--- a/rollup/shared.js
+++ b/rollup/shared.js
@@ -1,46 +1,39 @@
-import babel from 'rollup-plugin-babel'
-import commonjs from 'rollup-plugin-commonjs'
-import resolve from 'rollup-plugin-node-resolve'
-import uglify from 'rollup-plugin-uglify'
-import json from 'rollup-plugin-json'
+import babel from "rollup-plugin-babel"
+import commonjs from "rollup-plugin-commonjs"
+import resolve from "rollup-plugin-node-resolve"
+import uglify from "rollup-plugin-uglify"
+import json from "rollup-plugin-json"
 
 const pusherPlatformExports = [
-  'BaseClient',
-  'HOST_BASE',
-  'Instance',
-  'sendRawRequest'
+  "BaseClient",
+  "HOST_BASE",
+  "Instance",
+  "sendRawRequest",
 ]
 
 export default {
-  input: 'src/main.js',
+  input: "src/main.js",
   plugins: [
     json(),
     babel({
       presets: [
         [
-          'env',
+          "env",
           {
-            modules: false
-          }
-        ]
+            modules: false,
+          },
+        ],
       ],
-      plugins: [
-        'external-helpers',
-        'transform-class-properties',
-        'transform-object-rest-spread'
-      ],
-      exclude: [
-        'node_modules/**'
-      ]
+      plugins: ["external-helpers", "transform-object-rest-spread"],
+      exclude: ["node_modules/**"],
     }),
     resolve(),
     commonjs({
       namedExports: {
-        'node_modules/pusher-platform/dist/web/pusher-platform.js':
-          pusherPlatformExports,
-        'node_modules/pusher-platform/react-native.js': pusherPlatformExports
-      }
+        "node_modules/pusher-platform/dist/web/pusher-platform.js": pusherPlatformExports,
+        "node_modules/pusher-platform/react-native.js": pusherPlatformExports,
+      },
     }),
-    uglify()
-  ]
+    uglify(),
+  ],
 }

--- a/rollup/web.js
+++ b/rollup/web.js
@@ -1,11 +1,11 @@
-import { merge } from 'ramda'
+import { merge } from "ramda"
 
-import shared from './shared'
+import shared from "./shared"
 
 export default merge(shared, {
   output: {
-    file: 'dist/web/chatkit.js',
-    format: 'umd',
-    name: 'Chatkit'
-  }
+    file: "dist/web/chatkit.js",
+    format: "umd",
+    name: "Chatkit",
+  },
 })

--- a/src/chat-manager.js
+++ b/src/chat-manager.js
@@ -1,66 +1,71 @@
-import { BaseClient, HOST_BASE, Instance } from 'pusher-platform'
-import { split } from 'ramda'
+import { BaseClient, HOST_BASE, Instance } from "pusher-platform"
+import { split } from "ramda"
 
-import { CurrentUser } from './current-user'
-import { typeCheck, typeCheckObj } from './utils'
-import { DEFAULT_CONNECTION_TIMEOUT } from './constants'
+import { CurrentUser } from "./current-user"
+import { typeCheck, typeCheckObj } from "./utils"
+import { DEFAULT_CONNECTION_TIMEOUT } from "./constants"
 
-import { version } from '../package.json'
+import { version } from "../package.json"
 
 export class ChatManager {
-  constructor ({ instanceLocator, tokenProvider, userId, ...options } = {}) {
-    typeCheck('instanceLocator', 'string', instanceLocator)
-    typeCheck('tokenProvider', 'object', tokenProvider)
-    typeCheck('tokenProvider.fetchToken', 'function', tokenProvider.fetchToken)
-    typeCheck('userId', 'string', userId)
-    const cluster = split(':', instanceLocator)[1]
+  constructor({ instanceLocator, tokenProvider, userId, ...options } = {}) {
+    typeCheck("instanceLocator", "string", instanceLocator)
+    typeCheck("tokenProvider", "object", tokenProvider)
+    typeCheck("tokenProvider.fetchToken", "function", tokenProvider.fetchToken)
+    typeCheck("userId", "string", userId)
+    const cluster = split(":", instanceLocator)[1]
     if (cluster === undefined) {
       throw new TypeError(
-        `expected instanceLocator to be of the format x:y:z, but was ${instanceLocator}`
+        `expected instanceLocator to be of the format x:y:z, but was ${instanceLocator}`,
       )
     }
-    const baseClient = options.baseClient || new BaseClient({
-      host: `${cluster}.${HOST_BASE}`,
-      logger: options.logger,
-      sdkProduct: 'chatkit',
-      sdkVersion: version
-    })
-    if (typeof tokenProvider.setUserId === 'function') {
+    const baseClient =
+      options.baseClient ||
+      new BaseClient({
+        host: `${cluster}.${HOST_BASE}`,
+        logger: options.logger,
+        sdkProduct: "chatkit",
+        sdkVersion: version,
+      })
+    if (typeof tokenProvider.setUserId === "function") {
       tokenProvider.setUserId(userId)
     }
     const instanceOptions = {
       client: baseClient,
       locator: instanceLocator,
       logger: options.logger,
-      tokenProvider
+      tokenProvider,
     }
     this.apiInstance = new Instance({
-      serviceName: 'chatkit',
-      serviceVersion: 'v2',
-      ...instanceOptions
+      serviceName: "chatkit",
+      serviceVersion: "v2",
+      ...instanceOptions,
     })
     this.filesInstance = new Instance({
-      serviceName: 'chatkit_files',
-      serviceVersion: 'v1',
-      ...instanceOptions
+      serviceName: "chatkit_files",
+      serviceVersion: "v1",
+      ...instanceOptions,
     })
     this.cursorsInstance = new Instance({
-      serviceName: 'chatkit_cursors',
-      serviceVersion: 'v2',
-      ...instanceOptions
+      serviceName: "chatkit_cursors",
+      serviceVersion: "v2",
+      ...instanceOptions,
     })
     this.presenceInstance = new Instance({
-      serviceName: 'chatkit_presence',
-      serviceVersion: 'v2',
-      ...instanceOptions
+      serviceName: "chatkit_presence",
+      serviceVersion: "v2",
+      ...instanceOptions,
     })
     this.userId = userId
     this.connectionTimeout =
       options.connectionTimeout || DEFAULT_CONNECTION_TIMEOUT
+
+    this.connect = this.connect.bind(this)
+    this.disconnect = this.disconnect.bind(this)
   }
 
-  connect = (hooks = {}) => {
-    typeCheckObj('hooks', 'function', hooks)
+  connect(hooks = {}) {
+    typeCheckObj("hooks", "function", hooks)
     const currentUser = new CurrentUser({
       hooks,
       id: this.userId,
@@ -68,18 +73,19 @@ export class ChatManager {
       filesInstance: this.filesInstance,
       cursorsInstance: this.cursorsInstance,
       presenceInstance: this.presenceInstance,
-      connectionTimeout: this.connectionTimeout
+      connectionTimeout: this.connectionTimeout,
     })
     return Promise.all([
       currentUser.establishUserSubscription(),
       currentUser.establishCursorSubscription(),
-      currentUser.establishPresenceSubscription()
-    ])
-      .then(() => {
-        this.currentUser = currentUser
-        return currentUser
-      })
+      currentUser.establishPresenceSubscription(),
+    ]).then(() => {
+      this.currentUser = currentUser
+      return currentUser
+    })
   }
 
-  disconnect = () => { if (this.currentUser) this.currentUser.disconnect() }
+  disconnect() {
+    if (this.currentUser) this.currentUser.disconnect()
+  }
 }

--- a/src/current-user.js
+++ b/src/current-user.js
@@ -10,48 +10,45 @@ import {
   prop,
   sort,
   uniq,
-  values
-} from 'ramda'
+  values,
+} from "ramda"
 
 import {
   checkOneOf,
   typeCheck,
   typeCheckArr,
   typeCheckObj,
-  urlEncode
-} from './utils'
-import {
-  parseBasicMessage,
-  parseBasicRoom
-} from './parsers'
-import { Store } from './store'
-import { UserStore } from './user-store'
-import { RoomStore } from './room-store'
-import { CursorStore } from './cursor-store'
-import { TypingIndicators } from './typing-indicators'
-import { UserSubscription } from './user-subscription'
-import { PresenceSubscription } from './presence-subscription'
-import { UserPresenceSubscription } from './user-presence-subscription'
-import { CursorSubscription } from './cursor-subscription'
-import { MessageSubscription } from './message-subscription'
-import { MembershipSubscription } from './membership-subscription'
-import { RoomSubscription } from './room-subscription'
-import { Message } from './message'
-import { SET_CURSOR_WAIT } from './constants'
+  urlEncode,
+} from "./utils"
+import { parseBasicMessage, parseBasicRoom } from "./parsers"
+import { Store } from "./store"
+import { UserStore } from "./user-store"
+import { RoomStore } from "./room-store"
+import { CursorStore } from "./cursor-store"
+import { TypingIndicators } from "./typing-indicators"
+import { UserSubscription } from "./user-subscription"
+import { PresenceSubscription } from "./presence-subscription"
+import { UserPresenceSubscription } from "./user-presence-subscription"
+import { CursorSubscription } from "./cursor-subscription"
+import { MessageSubscription } from "./message-subscription"
+import { MembershipSubscription } from "./membership-subscription"
+import { RoomSubscription } from "./room-subscription"
+import { Message } from "./message"
+import { SET_CURSOR_WAIT } from "./constants"
 
 export class CurrentUser {
-  constructor ({
+  constructor({
     apiInstance,
     connectionTimeout,
     cursorsInstance,
     filesInstance,
     hooks,
     id,
-    presenceInstance
+    presenceInstance,
   }) {
     this.hooks = {
       global: hooks,
-      rooms: {}
+      rooms: {},
     }
     this.id = id
     this.encodedId = encodeURIComponent(this.id)
@@ -65,61 +62,94 @@ export class CurrentUser {
     this.userStore = new UserStore({
       instance: this.apiInstance,
       presenceStore: this.presenceStore,
-      logger: this.logger
+      logger: this.logger,
     })
     this.roomStore = new RoomStore({
       instance: this.apiInstance,
       userStore: this.userStore,
       isSubscribedTo: this.isSubscribedTo,
-      logger: this.logger
+      logger: this.logger,
     })
     this.cursorStore = new CursorStore({
       instance: this.cursorsInstance,
       userStore: this.userStore,
       roomStore: this.roomStore,
-      logger: this.logger
+      logger: this.logger,
     })
     this.typingIndicators = new TypingIndicators({
       hooks: this.hooks,
       instance: this.apiInstance,
-      logger: this.logger
+      logger: this.logger,
     })
-    this.userStore.onSetHooks.push(this.subscribeToUserPresence)
+    this.userStore.onSetHooks.push(userId =>
+      this.subscribeToUserPresence(userId),
+    )
     this.userStore.initialize({})
     this.presenceStore.initialize({})
     this.cursorStore.initialize({})
     this.roomSubscriptions = {}
     this.readCursorBuffer = {} // roomId -> { position, [{ resolve, reject }] }
     this.userPresenceSubscriptions = {}
+
+    this.setReadCursor = this.setReadCursor.bind(this)
+    this.readCursor = this.readCursor.bind(this)
+    this.isTypingIn = this.isTypingIn.bind(this)
+    this.createRoom = this.createRoom.bind(this)
+    this.getJoinableRooms = this.getJoinableRooms.bind(this)
+    this.joinRoom = this.joinRoom.bind(this)
+    this.leaveRoom = this.leaveRoom.bind(this)
+    this.addUserToRoom = this.addUserToRoom.bind(this)
+    this.removeUserFromRoom = this.removeUserFromRoom.bind(this)
+    this.sendMessage = this.sendMessage.bind(this)
+    this.fetchMessages = this.fetchMessages.bind(this)
+    this.subscribeToRoom = this.subscribeToRoom.bind(this)
+    this.updateRoom = this.updateRoom.bind(this)
+    this.deleteRoom = this.deleteRoom.bind(this)
+    this.setReadCursorRequest = this.setReadCursorRequest.bind(this)
+    this.uploadDataAttachment = this.uploadDataAttachment.bind(this)
+    this.isMemberOf = this.isMemberOf.bind(this)
+    this.isSubscribedTo = this.isSubscribedTo.bind(this)
+    this.decorateMessage = this.decorateMessage.bind(this)
+    this.establishUserSubscription = this.establishUserSubscription.bind(this)
+    this.establishCursorSubscription = this.establishCursorSubscription.bind(
+      this,
+    )
+    this.establishPresenceSubscription = this.establishPresenceSubscription.bind(
+      this,
+    )
+    this.subscribeToUserPresence = this.subscribeToUserPresence.bind(this)
+    this.disconnect = this.disconnect.bind(this)
   }
 
   /* public */
 
-  get rooms () {
+  get rooms() {
     return values(this.roomStore.snapshot())
   }
 
-  get users () {
+  get users() {
     return values(this.userStore.snapshot())
   }
 
-  setReadCursor = ({ roomId, position } = {}) => {
-    typeCheck('roomId', 'string', roomId)
-    typeCheck('position', 'number', position)
+  setReadCursor({ roomId, position } = {}) {
+    typeCheck("roomId", "string", roomId)
+    typeCheck("position", "number", position)
     return new Promise((resolve, reject) => {
       if (this.readCursorBuffer[roomId] !== undefined) {
-        this.readCursorBuffer[roomId].position =
-          max(this.readCursorBuffer[roomId].position, position)
+        this.readCursorBuffer[roomId].position = max(
+          this.readCursorBuffer[roomId].position,
+          position,
+        )
         this.readCursorBuffer[roomId].callbacks.push({ resolve, reject })
       } else {
         this.readCursorBuffer[roomId] = {
           position,
-          callbacks: [{ resolve, reject }]
+          callbacks: [{ resolve, reject }],
         }
         setTimeout(() => {
           this.setReadCursorRequest({
             roomId,
-            ...this.readCursorBuffer[roomId]
+            ...this.readCursorBuffer[roomId],
           })
           delete this.readCursorBuffer[roomId]
         }, SET_CURSOR_WAIT)
@@ -127,12 +157,12 @@ export class CurrentUser {
     })
   }
 
-  readCursor = ({ roomId, userId = this.id } = {}) => {
-    typeCheck('roomId', 'string', roomId)
-    typeCheck('userId', 'string', userId)
+  readCursor({ roomId, userId = this.id } = {}) {
+    typeCheck("roomId", "string", roomId)
+    typeCheck("userId", "string", userId)
     if (userId !== this.id && !this.isSubscribedTo(roomId)) {
       const err = new Error(
-        `Must be subscribed to room ${roomId} to access member's read cursors`
+        `Must be subscribed to room ${roomId} to access member's read cursors`,
       )
       this.logger.error(err)
       throw err
@@ -140,56 +170,64 @@ export class CurrentUser {
     return this.cursorStore.getSync(userId, roomId)
   }
 
-  isTypingIn = ({ roomId } = {}) => {
-    typeCheck('roomId', 'string', roomId)
+  isTypingIn({ roomId } = {}) {
+    typeCheck("roomId", "string", roomId)
     return this.typingIndicators.sendThrottledRequest(roomId)
   }
 
-  createRoom = ({ name, addUserIds, ...rest } = {}) => {
-    name && typeCheck('name', 'string', name)
-    addUserIds && typeCheckArr('addUserIds', 'string', addUserIds)
-    return this.apiInstance.request({
-      method: 'POST',
-      path: '/rooms',
-      json: {
-        created_by_id: this.id,
-        name,
-        private: !!rest.private, // private is a reserved word in strict mode!
-        user_ids: addUserIds
-      }
-    })
+  createRoom({ name, addUserIds, ...rest } = {}) {
+    name && typeCheck("name", "string", name)
+    addUserIds && typeCheckArr("addUserIds", "string", addUserIds)
+    return this.apiInstance
+      .request({
+        method: "POST",
+        path: "/rooms",
+        json: {
+          created_by_id: this.id,
+          name,
+          private: !!rest.private, // private is a reserved word in strict mode!
+          user_ids: addUserIds,
+        },
+      })
       .then(res => {
         const basicRoom = parseBasicRoom(JSON.parse(res))
         return this.roomStore.set(basicRoom.id, basicRoom)
       })
       .catch(err => {
-        this.logger.warn('error creating room:', err)
+        this.logger.warn("error creating room:", err)
         throw err
       })
   }
 
-  getJoinableRooms = () => {
+  getJoinableRooms() {
     return this.apiInstance
       .request({
-        method: 'GET',
-        path: `/users/${this.encodedId}/rooms?joinable=true`
+        method: "GET",
+        path: `/users/${this.encodedId}/rooms?joinable=true`,
       })
-      .then(pipe(JSON.parse, map(parseBasicRoom)))
+      .then(
+        pipe(
+          JSON.parse,
+          map(parseBasicRoom),
+        ),
+      )
       .catch(err => {
-        this.logger.warn('error getting joinable rooms:', err)
+        this.logger.warn("error getting joinable rooms:", err)
         throw err
       })
   }
 
-  joinRoom = ({ roomId } = {}) => {
-    typeCheck('roomId', 'string', roomId)
+  joinRoom({ roomId } = {}) {
+    typeCheck("roomId", "string", roomId)
     if (this.isMemberOf(roomId)) {
       return this.roomStore.get(roomId)
     }
     return this.apiInstance
       .request({
-        method: 'POST',
-        path: `/users/${this.encodedId}/rooms/${encodeURIComponent(roomId)}/join`
+        method: "POST",
+        path: `/users/${this.encodedId}/rooms/${encodeURIComponent(
+          roomId,
+        )}/join`,
       })
       .then(res => {
         const basicRoom = parseBasicRoom(JSON.parse(res))
@@ -201,31 +239,37 @@ export class CurrentUser {
       })
   }
 
-  leaveRoom = ({ roomId } = {}) => {
-    typeCheck('roomId', 'string', roomId)
-    return this.roomStore.get(roomId)
-      .then(room => this.apiInstance.request({
-        method: 'POST',
-        path: `/users/${this.encodedId}/rooms/${encodeURIComponent(roomId)}/leave`
-      })
-        .then(() => this.roomStore.pop(roomId))
-        .then(() => room))
+  leaveRoom({ roomId } = {}) {
+    typeCheck("roomId", "string", roomId)
+    return this.roomStore
+      .get(roomId)
+      .then(room =>
+        this.apiInstance
+          .request({
+            method: "POST",
+            path: `/users/${this.encodedId}/rooms/${encodeURIComponent(
+              roomId,
+            )}/leave`,
+          })
+          .then(() => this.roomStore.pop(roomId))
+          .then(() => room),
+      )
       .catch(err => {
         this.logger.warn(`error leaving room ${roomId}:`, err)
         throw err
       })
   }
 
-  addUserToRoom = ({ userId, roomId } = {}) => {
-    typeCheck('userId', 'string', userId)
-    typeCheck('roomId', 'string', roomId)
+  addUserToRoom({ userId, roomId } = {}) {
+    typeCheck("userId", "string", userId)
+    typeCheck("roomId", "string", roomId)
     return this.apiInstance
       .request({
-        method: 'PUT',
+        method: "PUT",
         path: `/rooms/${encodeURIComponent(roomId)}/users/add`,
         json: {
-          user_ids: [userId]
-        }
+          user_ids: [userId],
+        },
       })
       .then(() => this.roomStore.addUserToRoom(roomId, userId))
       .catch(err => {
@@ -234,75 +278,85 @@ export class CurrentUser {
       })
   }
 
-  removeUserFromRoom = ({ userId, roomId } = {}) => {
-    typeCheck('userId', 'string', userId)
-    typeCheck('roomId', 'string', roomId)
+  removeUserFromRoom({ userId, roomId } = {}) {
+    typeCheck("userId", "string", userId)
+    typeCheck("roomId", "string", roomId)
     return this.apiInstance
       .request({
-        method: 'PUT',
+        method: "PUT",
         path: `/rooms/${encodeURIComponent(roomId)}/users/remove`,
         json: {
-          user_ids: [userId]
-        }
+          user_ids: [userId],
+        },
       })
       .then(() => this.roomStore.removeUserFromRoom(roomId, userId))
       .catch(err => {
         this.logger.warn(
           `error removing user ${userId} from room ${roomId}:`,
-          err
+          err,
         )
         throw err
       })
   }
 
-  sendMessage = ({ text, roomId, attachment } = {}) => {
-    typeCheck('text', 'string', text)
-    typeCheck('roomId', 'string', roomId)
+  sendMessage({ text, roomId, attachment } = {}) {
+    typeCheck("text", "string", text)
+    typeCheck("roomId", "string", roomId)
     return new Promise((resolve, reject) => {
       if (attachment !== undefined && isDataAttachment(attachment)) {
         resolve(this.uploadDataAttachment(roomId, attachment))
       } else if (attachment !== undefined && isLinkAttachment(attachment)) {
         resolve({ resource_link: attachment.link, type: attachment.type })
       } else if (attachment !== undefined) {
-        reject(new TypeError('attachment was malformed'))
+        reject(new TypeError("attachment was malformed"))
       } else {
         resolve()
       }
     })
-      .then(attachment => this.apiInstance.request({
-        method: 'POST',
-        path: `/rooms/${encodeURIComponent(roomId)}/messages`,
-        json: { text, attachment }
-      }))
-      .then(pipe(JSON.parse, prop('message_id')))
+      .then(attachment =>
+        this.apiInstance.request({
+          method: "POST",
+          path: `/rooms/${encodeURIComponent(roomId)}/messages`,
+          json: { text, attachment },
+        }),
+      )
+      .then(
+        pipe(
+          JSON.parse,
+          prop("message_id"),
+        ),
+      )
       .catch(err => {
         this.logger.warn(`error sending message to room ${roomId}:`, err)
         throw err
       })
   }
 
-  fetchMessages = ({ roomId, initialId, limit, direction } = {}) => {
-    typeCheck('roomId', 'string', roomId)
-    initialId && typeCheck('initialId', 'number', initialId)
-    limit && typeCheck('limit', 'number', limit)
-    direction && checkOneOf('direction', ['older', 'newer'], direction)
+  fetchMessages({ roomId, initialId, limit, direction } = {}) {
+    typeCheck("roomId", "string", roomId)
+    initialId && typeCheck("initialId", "number", initialId)
+    limit && typeCheck("limit", "number", limit)
+    direction && checkOneOf("direction", ["older", "newer"], direction)
     return this.apiInstance
       .request({
-        method: 'GET',
+        method: "GET",
         path: `/rooms/${encodeURIComponent(roomId)}/messages?${urlEncode({
           initial_id: initialId,
           limit,
-          direction
-        })}`
+          direction,
+        })}`,
       })
       .then(res => {
         const messages = map(
-          compose(this.decorateMessage, parseBasicMessage),
-          JSON.parse(res)
+          compose(
+            this.decorateMessage,
+            parseBasicMessage,
+          ),
+          JSON.parse(res),
         )
-        return this.userStore.fetchMissingUsers(
-          uniq(map(prop('senderId'), messages))
-        ).then(() => sort((x, y) => x.id - y.id, messages))
+        return this.userStore
+          .fetchMissingUsers(uniq(map(prop("senderId"), messages)))
+          .then(() => sort((x, y) => x.id - y.id, messages))
       })
       .catch(err => {
         this.logger.warn(`error fetching messages from room ${roomId}:`, err)
@@ -310,10 +364,10 @@ export class CurrentUser {
       })
   }
 
-  subscribeToRoom = ({ roomId, hooks = {}, messageLimit } = {}) => {
-    typeCheck('roomId', 'string', roomId)
-    typeCheckObj('hooks', 'function', hooks)
-    messageLimit && typeCheck('messageLimit', 'number', messageLimit)
+  subscribeToRoom({ roomId, hooks = {}, messageLimit } = {}) {
+    typeCheck("roomId", "string", roomId)
+    typeCheckObj("hooks", "function", hooks)
+    messageLimit && typeCheck("messageLimit", "number", messageLimit)
     if (this.roomSubscriptions[roomId]) {
       this.roomSubscriptions[roomId].cancel()
     }
@@ -329,13 +383,14 @@ export class CurrentUser {
         roomStore: this.roomStore,
         typingIndicators: this.typingIndicators,
         logger: this.logger,
-        connectionTimeout: this.connectionTimeout
+        connectionTimeout: this.connectionTimeout,
       }),
       cursorSub: new CursorSubscription({
         onNewCursorHook: cursor => {
           if (
             this.hooks.rooms[roomId] &&
-            this.hooks.rooms[roomId].onNewReadCursor && cursor.type === 0 &&
+            this.hooks.rooms[roomId].onNewReadCursor &&
+            cursor.type === 0 &&
             cursor.userId !== this.id
           ) {
             this.hooks.rooms[roomId].onNewReadCursor(cursor)
@@ -345,7 +400,7 @@ export class CurrentUser {
         cursorStore: this.cursorStore,
         instance: this.cursorsInstance,
         logger: this.logger,
-        connectionTimeout: this.connectionTimeout
+        connectionTimeout: this.connectionTimeout,
       }),
       membershipSub: new MembershipSubscription({
         roomId,
@@ -354,8 +409,8 @@ export class CurrentUser {
         userStore: this.userStore,
         roomStore: this.roomStore,
         logger: this.logger,
-        connectionTimeout: this.connectionTimeout
-      })
+        connectionTimeout: this.connectionTimeout,
+      }),
     })
     return this.joinRoom({ roomId })
       .then(room => this.roomSubscriptions[roomId].connect().then(() => room))
@@ -365,78 +420,87 @@ export class CurrentUser {
       })
   }
 
-  updateRoom = ({ roomId, name, ...rest } = {}) => {
-    typeCheck('roomId', 'string', roomId)
-    name && typeCheck('name', 'string', name)
-    rest.private && typeCheck('private', 'boolean', rest.private)
-    return this.apiInstance.request({
-      method: 'PUT',
-      path: `/rooms/${encodeURIComponent(roomId)}`,
-      json: {
-        name,
-        private: rest.private // private is a reserved word in strict mode!
-      }
-    })
+  updateRoom({ roomId, name, ...rest } = {}) {
+    typeCheck("roomId", "string", roomId)
+    name && typeCheck("name", "string", name)
+    rest.private && typeCheck("private", "boolean", rest.private)
+    return this.apiInstance
+      .request({
+        method: "PUT",
+        path: `/rooms/${encodeURIComponent(roomId)}`,
+        json: {
+          name,
+          private: rest.private, // private is a reserved word in strict mode!
+        },
+      })
       .then(() => {})
       .catch(err => {
-        this.logger.warn('error updating room:', err)
+        this.logger.warn("error updating room:", err)
         throw err
       })
   }
 
-  deleteRoom = ({ roomId } = {}) => {
-    typeCheck('roomId', 'string', roomId)
-    return this.apiInstance.request({
-      method: 'DELETE',
-      path: `/rooms/${encodeURIComponent(roomId)}`
-    })
+  deleteRoom({ roomId } = {}) {
+    typeCheck("roomId", "string", roomId)
+    return this.apiInstance
+      .request({
+        method: "DELETE",
+        path: `/rooms/${encodeURIComponent(roomId)}`,
+      })
       .then(() => {})
       .catch(err => {
-        this.logger.warn('error deleting room:', err)
+        this.logger.warn("error deleting room:", err)
         throw err
       })
   }
 
   /* internal */
 
-  setReadCursorRequest = ({ roomId, position, callbacks }) => {
+  setReadCursorRequest({ roomId, position, callbacks }) {
     return this.cursorsInstance
       .request({
-        method: 'PUT',
-        path: `/cursors/0/rooms/${encodeURIComponent(roomId)}/users/${this.encodedId}`,
-        json: { position }
+        method: "PUT",
+        path: `/cursors/0/rooms/${encodeURIComponent(roomId)}/users/${
+          this.encodedId
+        }`,
+        json: { position },
       })
       .then(() => map(x => x.resolve(), callbacks))
       .catch(err => {
-        this.logger.warn('error setting cursor:', err)
+        this.logger.warn("error setting cursor:", err)
         map(x => x.reject(err), callbacks)
       })
   }
 
-  uploadDataAttachment = (roomId, { file, name }) => {
+  uploadDataAttachment(roomId, { file, name }) {
     // TODO some validation on allowed file names?
     // TODO polyfill FormData?
     const body = new FormData() // eslint-disable-line no-undef
-    body.append('file', file, name)
-    return this.filesInstance.request({
-      method: 'POST',
-      path: `/rooms/${encodeURIComponent(roomId)}/users/${this.encodedId}/files/${name}`,
-      body
-    })
+    body.append("file", file, name)
+    return this.filesInstance
+      .request({
+        method: "POST",
+        path: `/rooms/${encodeURIComponent(roomId)}/users/${
+          this.encodedId
+        }/files/${name}`,
+        body,
+      })
       .then(JSON.parse)
   }
 
-  isMemberOf = roomId => contains(roomId, map(prop('id'), this.rooms))
+  isMemberOf(roomId) {
+    return contains(roomId, map(prop("id"), this.rooms))
+  }
 
-  isSubscribedTo = roomId => has(roomId, this.roomSubscriptions)
+  isSubscribedTo(roomId) {
+    return has(roomId, this.roomSubscriptions)
+  }
 
-  decorateMessage = basicMessage => new Message(
-    basicMessage,
-    this.userStore,
-    this.roomStore
-  )
+  decorateMessage(basicMessage) {
+    return new Message(basicMessage, this.userStore, this.roomStore)
+  }
 
-  establishUserSubscription = () => {
+  establishUserSubscription() {
     this.userSubscription = new UserSubscription({
       hooks: this.hooks,
       userId: this.id,
@@ -445,28 +509,30 @@ export class CurrentUser {
       roomStore: this.roomStore,
       typingIndicators: this.typingIndicators,
       logger: this.logger,
-      connectionTimeout: this.connectionTimeout
+      connectionTimeout: this.connectionTimeout,
     })
-    return this.userSubscription.connect()
+    return this.userSubscription
+      .connect()
       .then(({ user, basicRooms }) => {
         this.avatarURL = user.avatarURL
         this.createdAt = user.createdAt
         this.customData = user.customData
         this.name = user.name
         this.updatedAt = user.updatedAt
-        this.roomStore.initialize(indexBy(prop('id'), basicRooms))
+        this.roomStore.initialize(indexBy(prop("id"), basicRooms))
       })
       .catch(err => {
-        this.logger.error('error establishing user subscription:', err)
+        this.logger.error("error establishing user subscription:", err)
         throw err
       })
   }
 
-  establishCursorSubscription = () => {
+  establishCursorSubscription() {
     this.cursorSubscription = new CursorSubscription({
       onNewCursorHook: cursor => {
         if (
-          this.hooks.global.onNewReadCursor && cursor.type === 0 &&
+          this.hooks.global.onNewReadCursor &&
+          cursor.type === 0 &&
           this.isMemberOf(cursor.roomId)
         ) {
           this.hooks.global.onNewReadCursor(cursor)
@@ -476,30 +542,28 @@ export class CurrentUser {
       cursorStore: this.cursorStore,
       instance: this.cursorsInstance,
       logger: this.logger,
-      connectionTimeout: this.connectionTimeout
+      connectionTimeout: this.connectionTimeout,
     })
-    return this.cursorSubscription.connect()
-      .catch(err => {
-        this.logger.error('error establishing cursor subscription:', err)
-        throw err
-      })
+    return this.cursorSubscription.connect().catch(err => {
+      this.logger.error("error establishing cursor subscription:", err)
+      throw err
+    })
   }
 
-  establishPresenceSubscription = () => {
+  establishPresenceSubscription() {
     this.presenceSubscription = new PresenceSubscription({
       userId: this.id,
       instance: this.presenceInstance,
       logger: this.logger,
-      connectionTimeout: this.connectionTimeout
+      connectionTimeout: this.connectionTimeout,
     })
-    return this.presenceSubscription.connect()
-      .catch(err => {
-        this.logger.warn('error establishing presence subscription:', err)
-        throw err
-      })
+    return this.presenceSubscription.connect().catch(err => {
+      this.logger.warn("error establishing presence subscription:", err)
+      throw err
+    })
   }
 
-  subscribeToUserPresence = userId => {
+  subscribeToUserPresence(userId) {
     if (this.userPresenceSubscriptions[userId]) {
       return Promise.resolve()
     }
@@ -516,14 +580,14 @@ export class CurrentUser {
       roomStore: this.roomStore,
       presenceStore: this.presenceStore,
       logger: this.logger,
-      connectionTimeout: this.connectionTimeout
+      connectionTimeout: this.connectionTimeout,
     })
 
     this.userPresenceSubscriptions[userId] = userPresenceSub
     return userPresenceSub.connect()
   }
 
-  disconnect = () => {
+  disconnect() {
     this.userSubscription.cancel()
     this.presenceSubscription.cancel()
     this.cursorSubscription.cancel()
@@ -536,8 +600,8 @@ const isDataAttachment = ({ file, name }) => {
   if (file === undefined || name === undefined) {
     return false
   }
-  typeCheck('attachment.file', 'object', file)
-  typeCheck('attachment.name', 'string', name)
+  typeCheck("attachment.file", "object", file)
+  typeCheck("attachment.name", "string", name)
   return true
 }
 
@@ -545,7 +609,7 @@ const isLinkAttachment = ({ link, type }) => {
   if (link === undefined || type === undefined) {
     return false
   }
-  typeCheck('attachment.link', 'string', link)
-  typeCheck('attachment.type', 'string', type)
+  typeCheck("attachment.link", "string", link)
+  typeCheck("attachment.type", "string", type)
   return true
 }

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -1,5 +1,5 @@
 export class Cursor {
-  constructor (basicCursor, userStore, roomStore) {
+  constructor(basicCursor, userStore, roomStore) {
     this.position = basicCursor.position
     this.updatedAt = basicCursor.updatedAt
     this.userId = basicCursor.userId
@@ -9,11 +9,11 @@ export class Cursor {
     this.roomStore = roomStore
   }
 
-  get user () {
+  get user() {
     return this.userStore.getSync(this.userId)
   }
 
-  get room () {
+  get room() {
     return this.roomStore.getSync(this.roomId)
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import { TokenProvider } from './token-provider'
-import { ChatManager } from './chat-manager'
+import { TokenProvider } from "./token-provider"
+import { ChatManager } from "./chat-manager"
 
 export default { TokenProvider, ChatManager }

--- a/src/message.js
+++ b/src/message.js
@@ -1,5 +1,5 @@
 export class Message {
-  constructor (basicMessage, userStore, roomStore) {
+  constructor(basicMessage, userStore, roomStore) {
     this.id = basicMessage.id
     this.senderId = basicMessage.senderId
     this.roomId = basicMessage.roomId
@@ -11,11 +11,11 @@ export class Message {
     this.roomStore = roomStore
   }
 
-  get sender () {
+  get sender() {
     return this.userStore.getSync(this.senderId)
   }
 
-  get room () {
+  get room() {
     return this.roomStore.getSync(this.roomId)
   }
 }

--- a/src/parsers.js
+++ b/src/parsers.js
@@ -1,4 +1,4 @@
-import { contains } from 'ramda'
+import { contains } from "ramda"
 
 export const parseBasicRoom = data => ({
   createdAt: data.created_at,
@@ -7,7 +7,7 @@ export const parseBasicRoom = data => ({
   id: data.id,
   isPrivate: data.private,
   name: data.name,
-  updatedAt: data.updated_at
+  updatedAt: data.updated_at,
 })
 
 export const parseBasicUser = data => ({
@@ -16,11 +16,11 @@ export const parseBasicUser = data => ({
   customData: data.custom_data,
   id: data.id,
   name: data.name,
-  updatedAt: data.updated_at
+  updatedAt: data.updated_at,
 })
 
 export const parsePresence = data => ({
-  state: contains(data.state, ['online', 'offline']) ? data.state : 'unknown'
+  state: contains(data.state, ["online", "offline"]) ? data.state : "unknown",
 })
 
 export const parseBasicMessage = data => ({
@@ -30,7 +30,7 @@ export const parseBasicMessage = data => ({
   text: data.text,
   createdAt: data.created_at,
   updatedAt: data.updated_at,
-  attachment: data.attachment && parseMessageAttachment(data.attachment)
+  attachment: data.attachment && parseMessageAttachment(data.attachment),
 })
 
 export const parseBasicCursor = data => ({
@@ -38,10 +38,10 @@ export const parseBasicCursor = data => ({
   updatedAt: data.updated_at,
   userId: data.user_id,
   roomId: data.room_id,
-  type: data.cursor_type
+  type: data.cursor_type,
 })
 
 const parseMessageAttachment = data => ({
   link: data.resource_link,
-  type: data.type
+  type: data.type,
 })

--- a/src/presence-subscription.js
+++ b/src/presence-subscription.js
@@ -1,15 +1,15 @@
 export class PresenceSubscription {
-  constructor (options) {
+  constructor(options) {
     this.userId = options.userId
     this.instance = options.instance
     this.logger = options.logger
     this.connectionTimeout = options.connectionTimeout
   }
 
-  connect () {
+  connect() {
     return new Promise((resolve, reject) => {
       this.timeout = setTimeout(() => {
-        reject(new Error('presence subscription timed out'))
+        reject(new Error("presence subscription timed out"))
       }, this.connectionTimeout)
       this.sub = this.instance.subscribeNonResuming({
         path: `/users/${encodeURIComponent(this.userId)}/register`,
@@ -21,18 +21,18 @@ export class PresenceSubscription {
           onError: err => {
             clearTimeout(this.timeout)
             reject(err)
-          }
-        }
+          },
+        },
       })
     })
   }
 
-  cancel () {
+  cancel() {
     clearTimeout(this.timeout)
     try {
       this.sub && this.sub.unsubscribe()
     } catch (err) {
-      this.logger.debug('error when cancelling presence subscription', err)
+      this.logger.debug("error when cancelling presence subscription", err)
     }
   }
 }

--- a/src/room-subscription.js
+++ b/src/room-subscription.js
@@ -1,19 +1,19 @@
 export class RoomSubscription {
-  constructor (options) {
+  constructor(options) {
     this.messageSub = options.messageSub
     this.cursorSub = options.cursorSub
     this.membershipSub = options.membershipSub
   }
 
-  connect () {
+  connect() {
     return Promise.all([
       this.messageSub.connect(),
       this.cursorSub.connect(),
-      this.membershipSub.connect()
+      this.membershipSub.connect(),
     ])
   }
 
-  cancel () {
+  cancel() {
     this.messageSub.cancel()
     this.cursorSub.cancel()
     this.membershipSub.cancel()

--- a/src/room.js
+++ b/src/room.js
@@ -1,7 +1,7 @@
-import { contains, filter, values } from 'ramda'
+import { contains, filter, values } from "ramda"
 
 export class Room {
-  constructor ({ basicRoom, userStore, isSubscribedTo, logger }) {
+  constructor({ basicRoom, userStore, isSubscribedTo, logger }) {
     this.createdAt = basicRoom.createdAt
     this.createdByUserId = basicRoom.createdByUserId
     this.deletedAt = basicRoom.deletedAt
@@ -15,17 +15,17 @@ export class Room {
     this.logger = logger
   }
 
-  get users () {
+  get users() {
     if (!this.isSubscribedTo(this.id)) {
       const err = new Error(
-        `Must be subscribed to room ${this.id} to access users property`
+        `Must be subscribed to room ${this.id} to access users property`,
       )
       this.logger.error(err)
       throw err
     }
     return filter(
       user => contains(user.id, this.userIds),
-      values(this.userStore.snapshot())
+      values(this.userStore.snapshot()),
     )
   }
 }

--- a/src/store.js
+++ b/src/store.js
@@ -1,20 +1,30 @@
-import { forEach } from 'ramda'
+import { forEach } from "ramda"
 
 export class Store {
-  pendingSets = [] // [{ key, value, resolve }]
-  pendingGets = [] // [{ key, resolve }]
+  constructor() {
+    this.pendingSets = [] // [{ key, value, resolve }]
+    this.pendingGets = [] // [{ key, resolve }]
 
-  initialize = initialStore => {
+    this.initialize = this.initialize.bind(this)
+    this.set = this.set.bind(this)
+    this.get = this.get.bind(this)
+    this.pop = this.pop.bind(this)
+    this.update = this.update.bind(this)
+    this.snapshot = this.snapshot.bind(this)
+    this.getSync = this.getSync.bind(this)
+  }
+
+  initialize(initialStore) {
     this.store = initialStore
     forEach(({ key, value, resolve }) => {
-      resolve(this.store[key] = value)
+      resolve((this.store[key] = value))
     }, this.pendingSets)
     forEach(({ key, resolve }) => {
       resolve(this.store[key])
     }, this.pendingGets)
   }
 
-  set = (key, value) => {
+  set(key, value) {
     if (this.store) {
       this.store[key] = value
       return Promise.resolve(value)
@@ -25,7 +35,7 @@ export class Store {
     }
   }
 
-  get = key => {
+  get(key) {
     if (this.store) {
       return Promise.resolve(this.store[key])
     } else {
@@ -35,18 +45,26 @@ export class Store {
     }
   }
 
-  pop = key => this.get(key).then(value => {
-    delete this.store[key]
-    return value
-  })
+  pop(key) {
+    return this.get(key).then(value => {
+      delete this.store[key]
+      return value
+    })
+  }
 
-  update = (key, f) => this.get(key).then(value => this.set(key, f(value)))
+  update(key, f) {
+    return this.get(key).then(value => this.set(key, f(value)))
+  }
 
   // snapshot and getSync are useful for building synchronous interfaces, but
   // should only be used when we can guarantee that the information we want is
   // already in the store (i.e. we've just done an explicit fetch)
 
-  snapshot = () => this.store || {}
+  snapshot() {
+    return this.store || {}
+  }
 
-  getSync = key => this.store ? this.store[key] : undefined
+  getSync(key) {
+    return this.store ? this.store[key] : undefined
+  }
 }

--- a/src/user.js
+++ b/src/user.js
@@ -1,5 +1,5 @@
 export class User {
-  constructor (basicUser, presenceStore) {
+  constructor(basicUser, presenceStore) {
     this.avatarURL = basicUser.avatarURL
     this.createdAt = basicUser.createdAt
     this.customData = basicUser.customData
@@ -9,9 +9,9 @@ export class User {
     this.presenceStore = presenceStore
   }
 
-  get presence () {
+  get presence() {
     return {
-      state: this.presenceStore.getSync(this.id) || 'unknown'
+      state: this.presenceStore.getSync(this.id) || "unknown",
     }
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,35 +5,35 @@ import {
   join,
   map,
   pipe,
-  toPairs
-} from 'ramda'
+  toPairs,
+} from "ramda"
 
 export const urlEncode = pipe(
   filter(x => x !== undefined),
   toPairs,
   map(([k, v]) => `${k}=${encodeURIComponent(v)}`),
-  join('&')
+  join("&"),
 )
 
 export const appendQueryParams = (queryParams, url) => {
-  const separator = contains('?', url) ? '&' : '?'
+  const separator = contains("?", url) ? "&" : "?"
   return url + separator + urlEncode(queryParams)
 }
 
 export const appendQueryParamsAsArray = (key, values, url) => {
-  const separator = contains('?', url) ? '' : '?'
+  const separator = contains("?", url) ? "" : "?"
   const encodedPairs = map(
     v => `${encodeURIComponent(key)}=${encodeURIComponent(v)}`,
-    values
+    values,
   )
-  return url + separator + join('&', encodedPairs)
+  return url + separator + join("&", encodedPairs)
 }
 
 export const typeCheck = (name, expectedType, value) => {
   const type = typeof value
   if (type !== expectedType) {
     throw new TypeError(
-      `expected ${name} to be of type ${expectedType} but was of type ${type}`
+      `expected ${name} to be of type ${expectedType} but was of type ${type}`,
     )
   }
 }
@@ -48,22 +48,19 @@ export const typeCheckArr = (name, expectedType, arr) => {
 
 // checks that all of an objects values are of the given type
 export const typeCheckObj = (name, expectedType, obj) => {
-  typeCheck(name, 'object', obj)
-  forEachObjIndexed((value, key) => typeCheck(key, expectedType, value), obj)
+  typeCheck(name, "object", obj)
+  forEachObjIndexed(
+    (value, key) => typeCheck(`${name}.${key}`, expectedType, value),
+    obj,
+  )
 }
 
 export const checkOneOf = (name, values, value) => {
   if (!contains(value, values)) {
     throw new TypeError(
-      `expected ${name} to be one of ${values} but was ${value}`
+      `expected ${name} to be one of ${values} but was ${value}`,
     )
   }
 }
 
 export const unixSeconds = () => Math.floor(Date.now() / 1000)
-
-// pointfree debugging
-export const trace = msg => x => {
-  console.log(msg, x)
-  return x
-}

--- a/tests/config/example.js
+++ b/tests/config/example.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 export const INSTANCE_KEY = "your:key"
 export const INSTANCE_LOCATOR = "your:instance:locator"
 export const TOKEN_PROVIDER_URL = "https://token.provider.url"

--- a/tests/config/example.js
+++ b/tests/config/example.js
@@ -1,3 +1,3 @@
-export const INSTANCE_KEY = 'your:key'
-export const INSTANCE_LOCATOR = 'your:instance:locator'
-export const TOKEN_PROVIDER_URL = 'https://token.provider.url'
+export const INSTANCE_KEY = "your:key"
+export const INSTANCE_LOCATOR = "your:instance:locator"
+export const TOKEN_PROVIDER_URL = "https://token.provider.url"

--- a/tests/main.js
+++ b/tests/main.js
@@ -1,6 +1,6 @@
 /* eslint-env browser */
 
-import test from 'tape'
+import test from "tape"
 import {
   any,
   compose,
@@ -13,19 +13,19 @@ import {
   map,
   reduce,
   tail,
-  toString
-} from 'ramda'
+  toString,
+} from "ramda"
 
-import ChatkitServer from '@pusher/chatkit-server'
+import ChatkitServer from "@pusher/chatkit-server"
 /* eslint-disable import/no-duplicates */
-import { TokenProvider, ChatManager } from '../dist/web/chatkit.js'
-import Chatkit from '../dist/web/chatkit.js'
+import { TokenProvider, ChatManager } from "../dist/web/chatkit.js"
+import Chatkit from "../dist/web/chatkit.js"
 /* eslint-enable import/no-duplicates */
 import {
   INSTANCE_LOCATOR,
   INSTANCE_KEY,
-  TOKEN_PROVIDER_URL
-} from './config/production'
+  TOKEN_PROVIDER_URL,
+} from "./config/production"
 
 let alicesRoom, bobsRoom, carolsRoom, alicesPrivateRoom
 let dataAttachmentUrl, bob, carol
@@ -34,7 +34,7 @@ const TEST_TIMEOUT = 15 * 1000
 
 const server = new ChatkitServer({
   instanceLocator: INSTANCE_LOCATOR,
-  key: INSTANCE_KEY
+  key: INSTANCE_KEY,
 })
 
 // batch(n, f) returns a function that on each call collects its arguments in
@@ -63,88 +63,101 @@ const batch = (n, f) => {
   }
 }
 
-const concatBatch = (n, f) => batch(n, compose(f, reduce(concat, [])))
+const concatBatch = (n, f) =>
+  batch(
+    n,
+    compose(
+      f,
+      reduce(concat, []),
+    ),
+  )
 
-const fetchUser = (t, userId, hooks = {}) => new ChatManager({
-  instanceLocator: INSTANCE_LOCATOR,
-  userId,
-  tokenProvider: new TokenProvider({ url: TOKEN_PROVIDER_URL }),
-  logger: {
-    error: console.log,
-    warn: console.log,
-    info: () => {},
-    debug: () => {},
-    verbose: () => {}
-  }
-}).connect(hooks).catch(endWithErr(t))
+const fetchUser = (t, userId, hooks = {}) =>
+  new ChatManager({
+    instanceLocator: INSTANCE_LOCATOR,
+    userId,
+    tokenProvider: new TokenProvider({ url: TOKEN_PROVIDER_URL }),
+    logger: {
+      error: console.log, // eslint-disable-line no-console
+      warn: console.log, // eslint-disable-line no-console
+      info: () => {},
+      debug: () => {},
+      verbose: () => {},
+    },
+  })
+    .connect(hooks)
+    .catch(endWithErr(t))
 
 const endWithErr = curry((t, err) => t.end(`error: ${toString(err)}`))
 
-const sendMessages = (user, room, texts) => length(texts) === 0
-  ? Promise.resolve()
-  : user.sendMessage({ roomId: room.id, text: head(texts) })
-    .then(() => sendMessages(user, room, tail(texts)))
+const sendMessages = (user, room, texts) =>
+  length(texts) === 0
+    ? Promise.resolve()
+    : user
+        .sendMessage({ roomId: room.id, text: head(texts) })
+        .then(() => sendMessages(user, room, tail(texts)))
 
 // Teardown first so that we can kill the tests at any time, safe in the
 // knowledge that we'll always be starting with a blank slate next time
 
-test('[teardown]', t => {
-  server.apiRequest({
-    method: 'DELETE',
-    path: '/resources',
-    jwt: server.generateAccessToken({ userId: 'admin', su: true }).token
-  })
+test("[teardown]", t => {
+  server
+    .apiRequest({
+      method: "DELETE",
+      path: "/resources",
+      jwt: server.generateAccessToken({ userId: "admin", su: true }).token,
+    })
     .then(() => t.end())
     .catch(endWithErr(t))
   t.timeoutAfter(TEST_TIMEOUT * 10)
 })
 
-test('[setup] create permissions', t => {
+test("[setup] create permissions", t => {
   Promise.all([
     server.createGlobalRole({
-      name: 'default',
+      name: "default",
       permissions: [
-        'message:create',
-        'room:join',
-        'room:leave',
-        'room:members:add',
-        'room:members:remove',
-        'room:get',
-        'room:create',
-        'room:messages:get',
-        'room:typing_indicator:create',
-        'presence:subscribe',
-        'user:get',
-        'user:rooms:get',
-        'file:get',
-        'file:create',
-        'cursors:read:get',
-        'cursors:read:set'
-      ]
+        "message:create",
+        "room:join",
+        "room:leave",
+        "room:members:add",
+        "room:members:remove",
+        "room:get",
+        "room:create",
+        "room:messages:get",
+        "room:typing_indicator:create",
+        "presence:subscribe",
+        "user:get",
+        "user:rooms:get",
+        "file:get",
+        "file:create",
+        "cursors:read:get",
+        "cursors:read:set",
+      ],
     }),
     server.createGlobalRole({
-      name: 'admin',
+      name: "admin",
       permissions: [
-        'message:create',
-        'room:join',
-        'room:leave',
-        'room:members:add',
-        'room:members:remove',
-        'room:get',
-        'room:create',
-        'room:messages:get',
-        'room:typing_indicator:create',
-        'presence:subscribe',
-        'user:get',
-        'user:rooms:get',
-        'file:get',
-        'file:create',
-        'cursors:read:get',
-        'cursors:read:set',
-        'room:delete',
-        'room:update'
-      ]
-    })
+        "message:create",
+        "room:join",
+        "room:leave",
+        "room:members:add",
+        "room:members:remove",
+        "room:get",
+        "room:create",
+        "room:messages:get",
+        "room:typing_indicator:create",
+        "presence:subscribe",
+        "user:get",
+        "user:rooms:get",
+        "file:get",
+        "file:create",
+        "cursors:read:get",
+        "cursors:read:set",
+        "room:delete",
+        "room:update",
+      ],
+    }),
   ])
     .then(() => t.end())
     .catch(endWithErr(t))
@@ -153,122 +166,137 @@ test('[setup] create permissions', t => {
 
 // Imports
 
-test('can import TokenProvider', t => {
-  t.equal(typeof TokenProvider, 'function')
+test("can import TokenProvider", t => {
+  t.equal(typeof TokenProvider, "function")
   t.end()
 })
 
-test('can import ChatManager', t => {
-  t.equal(typeof ChatManager, 'function')
+test("can import ChatManager", t => {
+  t.equal(typeof ChatManager, "function")
   t.end()
 })
 
-test('can import default', t => {
-  t.equal(typeof Chatkit, 'object')
-  t.equal(typeof Chatkit.TokenProvider, 'function')
-  t.equal(typeof Chatkit.ChatManager, 'function')
+test("can import default", t => {
+  t.equal(typeof Chatkit, "object")
+  t.equal(typeof Chatkit.TokenProvider, "function")
+  t.equal(typeof Chatkit.ChatManager, "function")
   t.end()
 })
 
 // Token provider
 
-test('instantiate TokenProvider with url', t => {
+test("instantiate TokenProvider with url", t => {
   const tokenProvider = new TokenProvider({ url: TOKEN_PROVIDER_URL })
-  t.equal(typeof tokenProvider, 'object')
-  t.equal(typeof tokenProvider.fetchToken, 'function')
+  t.equal(typeof tokenProvider, "object")
+  t.equal(typeof tokenProvider.fetchToken, "function")
   t.end()
 })
 
-test('instantiate TokenProvider with non-string url fails', t => {
+test("instantiate TokenProvider with non-string url fails", t => {
   t.throws(() => new TokenProvider({ url: 42 }), /url/)
   t.end()
 })
 
 // Chat manager
 
-test('instantiate ChatManager with correct params', t => {
+test("instantiate ChatManager with correct params", t => {
   const chatManager = new ChatManager({
     instanceLocator: INSTANCE_LOCATOR,
-    userId: 'alice',
-    tokenProvider: new TokenProvider({ url: TOKEN_PROVIDER_URL })
+    userId: "alice",
+    tokenProvider: new TokenProvider({ url: TOKEN_PROVIDER_URL }),
   })
-  t.equal(typeof chatManager, 'object')
-  t.equal(typeof chatManager.connect, 'function')
+  t.equal(typeof chatManager, "object")
+  t.equal(typeof chatManager.connect, "function")
   t.end()
 })
 
-test('instantiate ChatManager with non-string instanceLocator fails', t => {
-  t.throws(() => new ChatManager({
-    instanceLocator: 42,
-    userId: 'alice',
-    tokenProvider: new TokenProvider({ url: TOKEN_PROVIDER_URL })
-  }), /instanceLocator/)
-  t.end()
-})
-
-test('instantiate ChatManager without userId fails', t => {
-  t.throws(() => new ChatManager({
-    instanceLocator: INSTANCE_LOCATOR,
-    userId: 42,
-    tokenProvider: new TokenProvider({ url: TOKEN_PROVIDER_URL })
-  }), /userId/)
-  t.end()
-})
-
-test('instantiate ChatManager with non-string userId fails', t => {
-  t.throws(() => new ChatManager({
-    instanceLocator: INSTANCE_LOCATOR,
-    userId: 42,
-    tokenProvider: new TokenProvider({ url: TOKEN_PROVIDER_URL })
-  }), /string/)
-  t.end()
-})
-
-test('instantiate ChatManager with non tokenProvider fails', t => {
-  t.throws(() => new ChatManager({
-    instanceLocator: INSTANCE_LOCATOR,
-    userId: 42,
-    tokenProvider: { foo: 'bar' }
-  }), /tokenProvider/)
-  t.end()
-})
-
-test('connection fails if provided with non-function hooks', t => {
-  const chatManager = new ChatManager({
-    instanceLocator: INSTANCE_LOCATOR,
-    userId: 'alice',
-    tokenProvider: new TokenProvider({ url: TOKEN_PROVIDER_URL })
-  })
+test("instantiate ChatManager with non-string instanceLocator fails", t => {
   t.throws(
-    () => chatManager.connect({ nonFunction: 42 }),
-    /nonFunction/
+    () =>
+      new ChatManager({
+        instanceLocator: 42,
+        userId: "alice",
+        tokenProvider: new TokenProvider({ url: TOKEN_PROVIDER_URL }),
+      }),
+    /instanceLocator/,
   )
   t.end()
 })
 
-test('connection fails for nonexistent user', t => {
+test("instantiate ChatManager without userId fails", t => {
+  t.throws(
+    () =>
+      new ChatManager({
+        instanceLocator: INSTANCE_LOCATOR,
+        userId: 42,
+        tokenProvider: new TokenProvider({ url: TOKEN_PROVIDER_URL }),
+      }),
+    /userId/,
+  )
+  t.end()
+})
+
+test("instantiate ChatManager with non-string userId fails", t => {
+  t.throws(
+    () =>
+      new ChatManager({
+        instanceLocator: INSTANCE_LOCATOR,
+        userId: 42,
+        tokenProvider: new TokenProvider({ url: TOKEN_PROVIDER_URL }),
+      }),
+    /string/,
+  )
+  t.end()
+})
+
+test("instantiate ChatManager with non tokenProvider fails", t => {
+  t.throws(
+    () =>
+      new ChatManager({
+        instanceLocator: INSTANCE_LOCATOR,
+        userId: 42,
+        tokenProvider: { foo: "bar" },
+      }),
+    /tokenProvider/,
+  )
+  t.end()
+})
+
+test("connection fails if provided with non-function hooks", t => {
   const chatManager = new ChatManager({
     instanceLocator: INSTANCE_LOCATOR,
-    userId: 'alice',
-    tokenProvider: new TokenProvider({ url: TOKEN_PROVIDER_URL })
+    userId: "alice",
+    tokenProvider: new TokenProvider({ url: TOKEN_PROVIDER_URL }),
   })
-  chatManager.connect()
+  t.throws(() => chatManager.connect({ nonFunction: 42 }), /nonFunction/)
+  t.end()
+})
+
+test("connection fails for nonexistent user", t => {
+  const chatManager = new ChatManager({
+    instanceLocator: INSTANCE_LOCATOR,
+    userId: "alice",
+    tokenProvider: new TokenProvider({ url: TOKEN_PROVIDER_URL }),
+  })
+  chatManager
+    .connect()
     .then(() => {
-      t.end('promise should not resolve')
+      t.end("promise should not resolve")
     })
     .catch(err => {
       t.true(
         toString(err).match(/user does not exist/),
-        'user does not exist error'
+        "user does not exist error",
       )
       t.end()
     })
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
-test('[setup] create Alice', t => {
-  server.createUser({ id: 'alice', name: 'Alice' })
-    .then(() => server.createRoom({ creatorId: 'alice', name: `Alice's room` }))
+test("[setup] create Alice", t => {
+  server
+    .createUser({ id: "alice", name: "Alice" })
+    .then(() => server.createRoom({ creatorId: "alice", name: `Alice's room` }))
     .then(room => {
       alicesRoom = room // we'll want this in the following tests
       t.end()
@@ -277,17 +305,17 @@ test('[setup] create Alice', t => {
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
-test('connection resolves with current user object', t => {
-  fetchUser(t, 'alice')
+test("connection resolves with current user object", t => {
+  fetchUser(t, "alice")
     .then(alice => {
-      t.equal(typeof alice, 'object')
-      t.equal(alice.id, 'alice')
-      t.equal(alice.name, 'Alice')
-      t.true(Array.isArray(alice.rooms), 'alice.rooms is an array')
+      t.equal(typeof alice, "object")
+      t.equal(alice.id, "alice")
+      t.equal(alice.name, "Alice")
+      t.true(Array.isArray(alice.rooms), "alice.rooms is an array")
       t.equal(length(alice.rooms), 1)
       t.equal(alice.rooms[0].name, `Alice's room`)
       t.equal(alice.rooms[0].isPrivate, false)
-      t.equal(alice.rooms[0].createdByUserId, 'alice')
+      t.equal(alice.rooms[0].createdByUserId, "alice")
       alice.disconnect()
       t.end()
     })
@@ -297,8 +325,8 @@ test('connection resolves with current user object', t => {
 
 // User subscription
 
-test('own read cursor undefined if not set', t => {
-  fetchUser(t, 'alice')
+test("own read cursor undefined if not set", t => {
+  fetchUser(t, "alice")
     .then(alice => {
       t.equal(alice.readCursor({ roomId: alicesRoom.id }), undefined)
       alice.disconnect()
@@ -308,18 +336,21 @@ test('own read cursor undefined if not set', t => {
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
-test('new read cursor hook [Alice sets her read cursor in her room]', t => {
+test("new read cursor hook [Alice sets her read cursor in her room]", t => {
   let mobileAlice, browserAlice
-  Promise.all([fetchUser(t, 'alice'), fetchUser(t, 'alice', {
-    onNewReadCursor: cursor => {
-      t.equal(cursor.position, 42)
-      t.equal(cursor.user.name, 'Alice')
-      t.equal(cursor.room.name, `Alice's room`)
-      mobileAlice.disconnect()
-      browserAlice.disconnect()
-      t.end()
-    }
-  })])
+  Promise.all([
+    fetchUser(t, "alice"),
+    fetchUser(t, "alice", {
+      onNewReadCursor: cursor => {
+        t.equal(cursor.position, 42)
+        t.equal(cursor.user.name, "Alice")
+        t.equal(cursor.room.name, `Alice's room`)
+        mobileAlice.disconnect()
+        browserAlice.disconnect()
+        t.end()
+      },
+    }),
+  ])
     .then(([m, b]) => {
       mobileAlice = m
       browserAlice = b
@@ -329,12 +360,12 @@ test('new read cursor hook [Alice sets her read cursor in her room]', t => {
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
-test('get own read cursor', t => {
-  fetchUser(t, 'alice')
+test("get own read cursor", t => {
+  fetchUser(t, "alice")
     .then(alice => {
       const cursor = alice.readCursor({ roomId: alicesRoom.id })
       t.equal(cursor.position, 42)
-      t.equal(cursor.user.name, 'Alice')
+      t.equal(cursor.user.name, "Alice")
       t.equal(cursor.room.name, `Alice's room`)
       alice.disconnect()
       t.end()
@@ -345,26 +376,30 @@ test('get own read cursor', t => {
 
 test(`added to room hook [creates Bob & Bob's room]`, t => {
   let alice
-  fetchUser(t, 'alice', {
+  fetchUser(t, "alice", {
     onAddedToRoom: room => {
       t.equal(room.name, `Bob's room`)
       t.true(
         any(r => r.id === room.id, alice.rooms),
-        `should contain Bob's room`
+        `should contain Bob's room`,
       )
       const br = find(r => r.id === room.id, alice.rooms)
       t.true(br, `alice.rooms should contain Bob's room`)
       alice.disconnect()
       t.end()
-    }
+    },
   })
-    .then(a => { alice = a })
-    .then(() => server.createUser({ id: 'bob', name: 'Bob' }))
-    .then(() => server.createRoom({
-      creatorId: 'bob',
-      name: `Bob's room`,
-      userIds: ['alice']
-    }))
+    .then(a => {
+      alice = a
+    })
+    .then(() => server.createUser({ id: "bob", name: "Bob" }))
+    .then(() =>
+      server.createRoom({
+        creatorId: "bob",
+        name: `Bob's room`,
+        userIds: ["alice"],
+      }),
+    )
     .then(room => {
       bobsRoom = room // we'll want this in the following tests
     })
@@ -374,22 +409,22 @@ test(`added to room hook [creates Bob & Bob's room]`, t => {
 
 // Presence Subscription
 
-test('user came online hook (presence sub)', t => {
+test("user came online hook (presence sub)", t => {
   let alice
-  fetchUser(t, 'alice', {
+  fetchUser(t, "alice", {
     onPresenceChanged: (state, user) => {
-      t.equal(state.current, 'online')
-      t.equal(state.previous, 'unknown')
-      t.equal(user.id, 'bob')
-      t.equal(user.presence.state, 'online')
+      t.equal(state.current, "online")
+      t.equal(state.previous, "unknown")
+      t.equal(user.id, "bob")
+      t.equal(user.presence.state, "online")
       alice.disconnect()
       t.end()
-    }
+    },
   })
     .then(a => {
       alice = a
     })
-    .then(() => fetchUser(t, 'bob'))
+    .then(() => fetchUser(t, "bob"))
     .then(b => {
       bob = b
     })
@@ -398,20 +433,20 @@ test('user came online hook (presence sub)', t => {
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
-test('user went offline hook (presence sub)', t => {
+test("user went offline hook (presence sub)", t => {
   let alice
-  fetchUser(t, 'alice', {
+  fetchUser(t, "alice", {
     onPresenceChanged: (state, user) => {
-      if (state.previous === 'unknown') {
+      if (state.previous === "unknown") {
         return // ignore the initial state, we only care about the transition
       }
-      t.equal(state.current, 'offline')
-      t.equal(state.previous, 'online')
-      t.equal(user.id, 'bob')
-      t.equal(user.presence.state, 'offline')
+      t.equal(state.current, "offline")
+      t.equal(state.previous, "online")
+      t.equal(user.id, "bob")
+      t.equal(user.presence.state, "offline")
       alice.disconnect()
       t.end()
-    }
+    },
   })
     .then(a => {
       alice = a
@@ -422,15 +457,15 @@ test('user went offline hook (presence sub)', t => {
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
-test('user left room hook (user sub) [removes Bob from his own room]', t => {
+test("user left room hook (user sub) [removes Bob from his own room]", t => {
   let alice
-  fetchUser(t, 'alice', {
+  fetchUser(t, "alice", {
     onUserLeftRoom: (room, user) => {
       t.equal(room.id, bobsRoom.id)
-      t.equal(user.id, 'bob')
+      t.equal(user.id, "bob")
       alice.disconnect()
       t.end()
-    }
+    },
   })
     .then(a => {
       alice = a
@@ -438,26 +473,26 @@ test('user left room hook (user sub) [removes Bob from his own room]', t => {
     .then(() => alice.subscribeToRoom({ roomId: bobsRoom.id }))
     .then(() => {
       server.apiRequest({
-        method: 'PUT',
+        method: "PUT",
         path: `/rooms/${encodeURIComponent(bobsRoom.id)}/users/remove`,
-        body: { user_ids: ['bob'] },
-        jwt: server.generateAccessToken({ userId: 'admin', su: true }).token
+        body: { user_ids: ["bob"] },
+        jwt: server.generateAccessToken({ userId: "admin", su: true }).token,
       })
     })
     .catch(endWithErr(t))
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
-test('user joined room hook (user sub) [Bob rejoins his own room]', t => {
+test("user joined room hook (user sub) [Bob rejoins his own room]", t => {
   let alice
-  fetchUser(t, 'alice', {
+  fetchUser(t, "alice", {
     onUserJoinedRoom: (room, user) => {
-      t.equal(user.id, 'bob')
+      t.equal(user.id, "bob")
       t.equal(room.id, bobsRoom.id)
-      t.true(contains('bob', room.userIds), `bob's room updated`)
+      t.true(contains("bob", room.userIds), `bob's room updated`)
       alice.disconnect()
       t.end()
-    }
+    },
   })
     .then(a => {
       alice = a
@@ -466,33 +501,33 @@ test('user joined room hook (user sub) [Bob rejoins his own room]', t => {
     .then(() => {
       bobsRoom = find(r => r.id === bobsRoom.id, alice.rooms)
       server.apiRequest({
-        method: 'PUT',
+        method: "PUT",
         path: `/rooms/${encodeURIComponent(bobsRoom.id)}/users/add`,
-        body: { user_ids: ['bob'] },
-        jwt: server.generateAccessToken({ userId: 'admin', su: true }).token
+        body: { user_ids: ["bob"] },
+        jwt: server.generateAccessToken({ userId: "admin", su: true }).token,
       })
     })
     .catch(endWithErr(t))
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
-test('room updated hook', t => {
+test("room updated hook", t => {
   let alice
-  fetchUser(t, 'alice', {
+  fetchUser(t, "alice", {
     onRoomUpdated: room => {
       t.equal(room.id, bobsRoom.id)
       t.equal(room.name, `Bob's renamed room`)
       alice.disconnect()
       t.end()
-    }
+    },
   })
     .then(a => {
       alice = a
       server.apiRequest({
-        method: 'PUT',
+        method: "PUT",
         path: `/rooms/${encodeURIComponent(bobsRoom.id)}`,
         body: { name: `Bob's renamed room` },
-        jwt: server.generateAccessToken({ userId: 'admin', su: true }).token
+        jwt: server.generateAccessToken({ userId: "admin", su: true }).token,
       })
     })
     .catch(endWithErr(t))
@@ -501,20 +536,20 @@ test('room updated hook', t => {
 
 test(`removed from room hook [removes Alice from Bob's room]`, t => {
   let alice
-  fetchUser(t, 'alice', {
+  fetchUser(t, "alice", {
     onRemovedFromRoom: room => {
       t.equal(room.id, bobsRoom.id)
       alice.disconnect()
       t.end()
-    }
+    },
   })
     .then(a => {
       alice = a
       server.apiRequest({
-        method: 'PUT',
+        method: "PUT",
         path: `/rooms/${encodeURIComponent(bobsRoom.id)}/users/remove`,
-        body: { user_ids: ['alice'] },
-        jwt: server.generateAccessToken({ userId: 'admin', su: true }).token
+        body: { user_ids: ["alice"] },
+        jwt: server.generateAccessToken({ userId: "admin", su: true }).token,
       })
     })
     .catch(endWithErr(t))
@@ -523,19 +558,19 @@ test(`removed from room hook [removes Alice from Bob's room]`, t => {
 
 test(`room deleted hook [destroys Alice's room]`, t => {
   let alice
-  fetchUser(t, 'alice', {
+  fetchUser(t, "alice", {
     onRoomDeleted: room => {
       t.equal(room.id, alicesRoom.id)
       alice.disconnect()
       t.end()
-    }
+    },
   })
     .then(a => {
       alice = a
       server.apiRequest({
-        method: 'DELETE',
+        method: "DELETE",
         path: `/rooms/${alicesRoom.id}`,
-        jwt: server.generateAccessToken({ userId: 'admin', su: true }).token
+        jwt: server.generateAccessToken({ userId: "admin", su: true }).token,
       })
     })
     .catch(endWithErr(t))
@@ -544,7 +579,7 @@ test(`room deleted hook [destroys Alice's room]`, t => {
 
 test(`create room [creates Alice's new room]`, t => {
   let alice
-  fetchUser(t, 'alice')
+  fetchUser(t, "alice")
     .then(a => {
       alice = a
       const result = alice.createRoom({ name: `Alice's new room` })
@@ -554,13 +589,12 @@ test(`create room [creates Alice's new room]`, t => {
       alicesRoom = room
       t.equal(room.name, `Alice's new room`)
       t.false(room.isPrivate, `room shouldn't be private`)
-      t.equal(room.createdByUserId, 'alice')
-      alice.subscribeToRoom({ roomId: room.id })
-        .then(() => {
-          t.deepEqual(room.userIds, ['alice'])
-          alice.disconnect()
-          t.end()
-        })
+      t.equal(room.createdByUserId, "alice")
+      alice.subscribeToRoom({ roomId: room.id }).then(() => {
+        t.deepEqual(room.userIds, ["alice"])
+        alice.disconnect()
+        t.end()
+      })
     })
     .catch(endWithErr(t))
   t.timeoutAfter(TEST_TIMEOUT)
@@ -568,26 +602,25 @@ test(`create room [creates Alice's new room]`, t => {
 
 test(`create private room [creates Alice's private room]`, t => {
   let alice
-  fetchUser(t, 'alice')
+  fetchUser(t, "alice")
     .then(a => {
       alice = a
       const result = alice.createRoom({
         name: `Alice's private room`,
-        private: true
+        private: true,
       })
       return result
     })
     .then(room => {
       alicesPrivateRoom = room
       t.equal(room.name, `Alice's private room`)
-      t.true(room.isPrivate, 'room should be private')
-      t.equal(room.createdByUserId, 'alice')
-      alice.subscribeToRoom({ roomId: room.id })
-        .then(() => {
-          t.deepEqual(room.userIds, ['alice'])
-          alice.disconnect()
-          t.end()
-        })
+      t.true(room.isPrivate, "room should be private")
+      t.equal(room.createdByUserId, "alice")
+      alice.subscribeToRoom({ roomId: room.id }).then(() => {
+        t.deepEqual(room.userIds, ["alice"])
+        alice.disconnect()
+        t.end()
+      })
     })
     .catch(endWithErr(t))
   t.timeoutAfter(TEST_TIMEOUT)
@@ -595,12 +628,12 @@ test(`create private room [creates Alice's private room]`, t => {
 
 test(`create room with members [creates Bob's new room]`, t => {
   let bob
-  fetchUser(t, 'bob')
+  fetchUser(t, "bob")
     .then(b => {
       bob = b
       const result = bob.createRoom({
         name: `Bob's new room`,
-        addUserIds: ['alice']
+        addUserIds: ["alice"],
       })
       return result
     })
@@ -608,22 +641,22 @@ test(`create room with members [creates Bob's new room]`, t => {
       bobsRoom = room
       t.equal(room.name, `Bob's new room`)
       t.false(room.isPrivate, `room shouldn't be private`)
-      t.equal(room.createdByUserId, 'bob')
-      bob.subscribeToRoom({ roomId: room.id })
-        .then(() => {
-          t.deepEqual(room.userIds.sort(), ['alice', 'bob'])
-          bob.disconnect()
-          t.end()
-        })
+      t.equal(room.createdByUserId, "bob")
+      bob.subscribeToRoom({ roomId: room.id }).then(() => {
+        t.deepEqual(room.userIds.sort(), ["alice", "bob"])
+        bob.disconnect()
+        t.end()
+      })
     })
     .catch(endWithErr(t))
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
-test('get joined rooms', t => {
+test("get joined rooms", t => {
   const expectedRoomIds = [alicesRoom, bobsRoom, alicesPrivateRoom]
-    .map(r => r.id).sort()
-  fetchUser(t, 'alice')
+    .map(r => r.id)
+    .sort()
+  fetchUser(t, "alice")
     .then(alice => {
       t.deepEqual(map(r => r.id, alice.rooms).sort(), expectedRoomIds)
       alice.disconnect()
@@ -633,8 +666,8 @@ test('get joined rooms', t => {
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
-test('get joinable rooms', t => {
-  fetchUser(t, 'bob')
+test("get joinable rooms", t => {
+  fetchUser(t, "bob")
     .then(bob => {
       const result = bob.getJoinableRooms()
       bob.disconnect()
@@ -646,7 +679,7 @@ test('get joinable rooms', t => {
       t.false(ids.includes(bobsRoom.id), `shouldn't include Bob's room`)
       t.false(
         ids.includes(alicesPrivateRoom.id),
-        `shouldn't include Alice's private room`
+        `shouldn't include Alice's private room`,
       )
       t.end()
     })
@@ -655,110 +688,110 @@ test('get joinable rooms', t => {
 })
 
 test(`join room [Bob joins Alice's room]`, t => {
-  fetchUser(t, 'bob')
-    .then(bob => bob.joinRoom({ roomId: alicesRoom.id })
-      .then(room => {
-        bob.subscribeToRoom({ roomId: room.id })
-          .then(() => {
-            t.equal(room.id, alicesRoom.id)
-            t.equal(room.createdByUserId, 'alice')
-            t.true(
-              any(r => r.id === alicesRoom.id, bob.rooms),
-              `should include Alice's room`
-            )
-            t.deepEqual(room.userIds.sort(), ['alice', 'bob'])
-            bob.disconnect()
-            t.end()
-          })
-      })
+  fetchUser(t, "bob")
+    .then(bob =>
+      bob.joinRoom({ roomId: alicesRoom.id }).then(room => {
+        bob.subscribeToRoom({ roomId: room.id }).then(() => {
+          t.equal(room.id, alicesRoom.id)
+          t.equal(room.createdByUserId, "alice")
+          t.true(
+            any(r => r.id === alicesRoom.id, bob.rooms),
+            `should include Alice's room`,
+          )
+          t.deepEqual(room.userIds.sort(), ["alice", "bob"])
+          bob.disconnect()
+          t.end()
+        })
+      }),
     )
     .catch(endWithErr(t))
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
 test(`leave room [Bob leaves Alice's room]`, t => {
-  fetchUser(t, 'bob')
+  fetchUser(t, "bob")
     .then(bob => {
       t.true(
         any(r => r.id === alicesRoom.id, bob.rooms),
-        `should include Bob's room`
+        `should include Bob's room`,
       )
-      bob.leaveRoom({ roomId: alicesRoom.id })
-        .then(room => {
-          t.equal(room.id, alicesRoom.id)
-          t.false(
-            any(r => r.id === alicesRoom.id, bob.rooms),
-            `shouldn't include Alice's room`
-          )
-          bob.disconnect()
-          t.end()
-        })
+      bob.leaveRoom({ roomId: alicesRoom.id }).then(room => {
+        t.equal(room.id, alicesRoom.id)
+        t.false(
+          any(r => r.id === alicesRoom.id, bob.rooms),
+          `shouldn't include Alice's room`,
+        )
+        bob.disconnect()
+        t.end()
+      })
     })
     .catch(endWithErr(t))
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
-test('add user [Alice adds Bob to her room]', t => {
-  fetchUser(t, 'alice')
-    .then(alice => alice.addUserToRoom({
-      userId: 'bob',
-      roomId: alicesRoom.id
-    })
+test("add user [Alice adds Bob to her room]", t => {
+  fetchUser(t, "alice").then(alice =>
+    alice
+      .addUserToRoom({
+        userId: "bob",
+        roomId: alicesRoom.id,
+      })
       .then(() => {
         const room = find(r => r.id === alicesRoom.id, alice.rooms)
-        alice.subscribeToRoom({ roomId: room.id })
-          .then(() => {
-            t.deepEqual(room.userIds.sort(), ['alice', 'bob'])
-            alice.disconnect()
-            t.end()
-          })
+        alice.subscribeToRoom({ roomId: room.id }).then(() => {
+          t.deepEqual(room.userIds.sort(), ["alice", "bob"])
+          alice.disconnect()
+          t.end()
+        })
       })
-      .catch(endWithErr(t))
-    )
+      .catch(endWithErr(t)),
+  )
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
-test('remove user [Alice removes Bob from her room]', t => {
-  fetchUser(t, 'alice')
-    .then(alice => alice.removeUserFromRoom({
-      userId: 'bob',
-      roomId: alicesRoom.id
-    })
+test("remove user [Alice removes Bob from her room]", t => {
+  fetchUser(t, "alice").then(alice =>
+    alice
+      .removeUserFromRoom({
+        userId: "bob",
+        roomId: alicesRoom.id,
+      })
       .then(() => {
         const room = find(r => r.id === alicesRoom.id, alice.rooms)
-        alice.subscribeToRoom({ roomId: room.id })
-          .then(() => {
-            t.deepEqual(room.userIds.sort(), ['alice'])
-            alice.disconnect()
-            t.end()
-          })
+        alice.subscribeToRoom({ roomId: room.id }).then(() => {
+          t.deepEqual(room.userIds.sort(), ["alice"])
+          alice.disconnect()
+          t.end()
+        })
       })
-      .catch(endWithErr(t))
-    )
+      .catch(endWithErr(t)),
+  )
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
 test(`send messages [sends four messages to Bob's room]`, t => {
-  fetchUser(t, 'alice')
-    .then(alice => sendMessages(alice, bobsRoom, [
-      'hello', 'hey', 'hi', 'ho'
-    ]).then(() => alice.disconnect()))
+  fetchUser(t, "alice")
+    .then(alice =>
+      sendMessages(alice, bobsRoom, ["hello", "hey", "hi", "ho"]).then(() =>
+        alice.disconnect(),
+      ),
+    )
     .then(t.end)
     .catch(endWithErr(t))
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
-test('fetch messages', t => {
+test("fetch messages", t => {
   let alice
-  fetchUser(t, 'alice')
+  fetchUser(t, "alice")
     .then(a => {
       alice = a
       return alice.fetchMessages({ roomId: bobsRoom.id })
     })
     .then(messages => {
-      t.deepEqual(messages.map(m => m.text), ['hello', 'hey', 'hi', 'ho'])
-      t.equal(messages[0].sender.id, 'alice')
-      t.equal(messages[0].sender.name, 'Alice')
+      t.deepEqual(messages.map(m => m.text), ["hello", "hey", "hi", "ho"])
+      t.equal(messages[0].sender.id, "alice")
+      t.equal(messages[0].sender.name, "Alice")
       t.equal(messages[0].room.id, bobsRoom.id)
       t.equal(messages[0].room.name, bobsRoom.name)
       alice.disconnect()
@@ -768,99 +801,119 @@ test('fetch messages', t => {
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
-test('fetch messages with pagination', t => {
-  fetchUser(t, 'alice')
-    .then(alice => alice.fetchMessages({ roomId: bobsRoom.id, limit: 2 })
-      .then(messages => {
-        t.deepEqual(messages.map(m => m.text), ['hi', 'ho'])
-        return messages[0].id
-      })
-      .then(initialId => alice.fetchMessages({
+test("fetch messages with pagination", t => {
+  fetchUser(t, "alice")
+    .then(alice =>
+      alice
+        .fetchMessages({ roomId: bobsRoom.id, limit: 2 })
+        .then(messages => {
+          t.deepEqual(messages.map(m => m.text), ["hi", "ho"])
+          return messages[0].id
+        })
+        .then(initialId =>
+          alice.fetchMessages({
+            roomId: bobsRoom.id,
+            initialId,
+          }),
+        )
+        .then(messages => {
+          t.deepEqual(messages.map(m => m.text), ["hello", "hey"])
+          alice.disconnect()
+          t.end()
+        }),
+    )
+    .catch(endWithErr(t))
+  t.timeoutAfter(TEST_TIMEOUT)
+})
+
+test("subscribe to room and fetch initial messages", t => {
+  fetchUser(t, "alice")
+    .then(alice =>
+      alice.subscribeToRoom({
         roomId: bobsRoom.id,
-        initialId
-      }))
-      .then(messages => {
-        t.deepEqual(messages.map(m => m.text), ['hello', 'hey'])
-        alice.disconnect()
-        t.end()
-      })
+        hooks: {
+          onMessage: concatBatch(4, messages => {
+            t.deepEqual(map(m => m.text, messages), [
+              "hello",
+              "hey",
+              "hi",
+              "ho",
+            ])
+            t.equal(messages[0].sender.name, "Alice")
+            t.equal(messages[0].room.name, `Bob's new room`)
+            alice.disconnect()
+            t.end()
+          }),
+        },
+      }),
     )
     .catch(endWithErr(t))
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
-test('subscribe to room and fetch initial messages', t => {
-  fetchUser(t, 'alice')
-    .then(alice => alice.subscribeToRoom({
-      roomId: bobsRoom.id,
-      hooks: {
-        onMessage: concatBatch(4, messages => {
-          t.deepEqual(map(m => m.text, messages), ['hello', 'hey', 'hi', 'ho'])
-          t.equal(messages[0].sender.name, 'Alice')
-          t.equal(messages[0].room.name, `Bob's new room`)
-          alice.disconnect()
-          t.end()
-        })
-      }
-    }))
-    .catch(endWithErr(t))
-  t.timeoutAfter(TEST_TIMEOUT)
-})
-
-test('subscribe to room and fetch last two message only', t => {
-  fetchUser(t, 'alice')
-    .then(alice => alice.subscribeToRoom({
-      roomId: bobsRoom.id,
-      hooks: {
-        onMessage: concatBatch(2, messages => {
-          t.deepEqual(map(m => m.text, messages), ['hi', 'ho'])
-          alice.disconnect()
-          t.end()
-        })
-      },
-      messageLimit: 2
-    }))
-    .catch(endWithErr(t))
-  t.timeoutAfter(TEST_TIMEOUT)
-})
-
-test('subscribe to room and receive sent messages', t => {
-  fetchUser(t, 'alice')
-    .then(alice => alice.subscribeToRoom({
-      roomId: bobsRoom.id,
-      hooks: {
-        onMessage: concatBatch(3, messages => {
-          t.deepEqual(map(m => m.text, messages), ['yo', 'yoo', 'yooo'])
-          t.equal(messages[0].sender.name, 'Alice')
-          t.equal(messages[0].room.name, `Bob's new room`)
-          alice.disconnect()
-          t.end()
-        })
-      },
-      messageLimit: 0
-    }).then(() => sendMessages(alice, bobsRoom, ['yo', 'yoo', 'yooo']))
+test("subscribe to room and fetch last two message only", t => {
+  fetchUser(t, "alice")
+    .then(alice =>
+      alice.subscribeToRoom({
+        roomId: bobsRoom.id,
+        hooks: {
+          onMessage: concatBatch(2, messages => {
+            t.deepEqual(map(m => m.text, messages), ["hi", "ho"])
+            alice.disconnect()
+            t.end()
+          }),
+        },
+        messageLimit: 2,
+      }),
     )
     .catch(endWithErr(t))
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
-test('unsubscribe from room', t => {
-  fetchUser(t, 'alice')
-    .then(alice => alice.subscribeToRoom({
-      roomId: bobsRoom.id,
-      hooks: {
-        onMessage: m => {
-          endWithErr(t, 'should not be called after unsubscribe')
-        }
-      },
-      messageLimit: 0
-    })
-      .then(() => alice.roomSubscriptions[bobsRoom.id].cancel())
-      .then(() => sendMessages(alice, bobsRoom, ['yoooo']))
-      .then(() => setTimeout(() => {
-        alice.disconnect()
-        t.end()
-      }, 1000))
+test("subscribe to room and receive sent messages", t => {
+  fetchUser(t, "alice")
+    .then(alice =>
+      alice
+        .subscribeToRoom({
+          roomId: bobsRoom.id,
+          hooks: {
+            onMessage: concatBatch(3, messages => {
+              t.deepEqual(map(m => m.text, messages), ["yo", "yoo", "yooo"])
+              t.equal(messages[0].sender.name, "Alice")
+              t.equal(messages[0].room.name, `Bob's new room`)
+              alice.disconnect()
+              t.end()
+            }),
+          },
+          messageLimit: 0,
+        })
+        .then(() => sendMessages(alice, bobsRoom, ["yo", "yoo", "yooo"])),
+    )
+    .catch(endWithErr(t))
+  t.timeoutAfter(TEST_TIMEOUT)
+})
+
+test("unsubscribe from room", t => {
+  fetchUser(t, "alice")
+    .then(alice =>
+      alice
+        .subscribeToRoom({
+          roomId: bobsRoom.id,
+          hooks: {
+            onMessage: () => {
+              endWithErr(t, "should not be called after unsubscribe")
+            },
+          },
+          messageLimit: 0,
+        })
+        .then(() => alice.roomSubscriptions[bobsRoom.id].cancel())
+        .then(() => sendMessages(alice, bobsRoom, ["yoooo"]))
+        .then(() =>
+          setTimeout(() => {
+            alice.disconnect()
+            t.end()
+          }, 1000),
+        ),
     )
     .catch(endWithErr(t))
   t.timeoutAfter(TEST_TIMEOUT)
@@ -868,99 +921,115 @@ test('unsubscribe from room', t => {
 
 // Attachments
 
-test('send message with malformed attachment fails', t => {
-  fetchUser(t, 'alice')
-    .then(alice => alice.sendMessage({
-      roomId: bobsRoom.id,
-      text: 'should fail',
-      attachment: { some: 'rubbish' }
-    })
+test("send message with malformed attachment fails", t => {
+  fetchUser(t, "alice").then(alice =>
+    alice
+      .sendMessage({
+        roomId: bobsRoom.id,
+        text: "should fail",
+        attachment: { some: "rubbish" },
+      })
       .catch(err => {
-        t.true(toString(err).match(/attachment/), 'attachment error')
+        t.true(toString(err).match(/attachment/), "attachment error")
         alice.disconnect()
         t.end()
-      }))
+      }),
+  )
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
 test(`send message with link attachment [sends a message to Bob's room]`, t => {
-  fetchUser(t, 'alice')
-    .then(alice => alice.sendMessage({
-      roomId: bobsRoom.id,
-      text: 'see attached link',
-      attachment: { link: 'https://cataas.com/cat', type: 'image' }
-    }).then(() => {
-      alice.disconnect()
-      t.end()
-    }))
+  fetchUser(t, "alice")
+    .then(alice =>
+      alice
+        .sendMessage({
+          roomId: bobsRoom.id,
+          text: "see attached link",
+          attachment: { link: "https://cataas.com/cat", type: "image" },
+        })
+        .then(() => {
+          alice.disconnect()
+          t.end()
+        }),
+    )
     .catch(endWithErr(t))
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
-test('receive message with link attachment', t => {
-  fetchUser(t, 'alice')
-    .then(alice => alice.fetchMessages({ roomId: bobsRoom.id, limit: 1 })
-      .then(([message]) => {
-        t.equal(message.text, 'see attached link')
-        t.deepEqual(message.attachment, {
-          link: 'https://cataas.com/cat',
-          type: 'image'
-        })
-        alice.disconnect()
-        t.end()
-      }))
+test("receive message with link attachment", t => {
+  fetchUser(t, "alice").then(alice =>
+    alice.fetchMessages({ roomId: bobsRoom.id, limit: 1 }).then(([message]) => {
+      t.equal(message.text, "see attached link")
+      t.deepEqual(message.attachment, {
+        link: "https://cataas.com/cat",
+        type: "image",
+      })
+      alice.disconnect()
+      t.end()
+    }),
+  )
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
 test(`send message with data attachment [sends a message to Bob's room]`, t => {
-  fetchUser(t, 'alice')
-    .then(alice => alice.sendMessage({
-      roomId: bobsRoom.id,
-      text: 'see attached json',
-      attachment: {
-        file: new File([JSON.stringify({ hello: 'world' })], {
-          type: 'application/json'
+  fetchUser(t, "alice")
+    .then(alice =>
+      alice
+        .sendMessage({
+          roomId: bobsRoom.id,
+          text: "see attached json",
+          attachment: {
+            file: new File([JSON.stringify({ hello: "world" })], {
+              type: "application/json",
+            }),
+            name: "hello.json",
+          },
+        })
+        .then(() => {
+          alice.disconnect()
+          t.end()
         }),
-        name: 'hello.json'
-      }
-    }).then(() => {
-      alice.disconnect()
-      t.end()
-    }))
+    )
     .catch(endWithErr(t))
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
-test('receive message with data attachment', t => {
-  fetchUser(t, 'alice')
-    .then(alice => alice.fetchMessages({ roomId: bobsRoom.id, limit: 1 })
-      .then(([message]) => {
-        t.equal(message.text, 'see attached json')
-        t.equal(message.attachment.type, 'file')
-        dataAttachmentUrl = message.attachment.link
-        alice.disconnect()
-        t.end()
-      }))
+test("receive message with data attachment", t => {
+  fetchUser(t, "alice")
+    .then(alice =>
+      alice
+        .fetchMessages({ roomId: bobsRoom.id, limit: 1 })
+        .then(([message]) => {
+          t.equal(message.text, "see attached json")
+          t.equal(message.attachment.type, "file")
+          dataAttachmentUrl = message.attachment.link
+          alice.disconnect()
+          t.end()
+        }),
+    )
     .catch(endWithErr(t))
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
-test('fetch data attachment', t => {
-  fetchUser(t, 'alice')
-    .then(alice => fetch(dataAttachmentUrl)
-      .then(res => res.json())
-      .then(data => {
-        t.deepEqual(data, { hello: 'world' })
-        alice.disconnect()
-        t.end()
-      }))
+test("fetch data attachment", t => {
+  fetchUser(t, "alice")
+    .then(alice =>
+      fetch(dataAttachmentUrl)
+        .then(res => res.json())
+        .then(data => {
+          t.deepEqual(data, { hello: "world" })
+          alice.disconnect()
+          t.end()
+        }),
+    )
     .catch(endWithErr(t))
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
-test('[setup] create Carol', t => {
-  server.createUser({ id: 'carol', name: 'Carol' })
-    .then(() => server.createRoom({ creatorId: 'carol', name: `Carol's room` }))
+test("[setup] create Carol", t => {
+  server
+    .createUser({ id: "carol", name: "Carol" })
+    .then(() => server.createRoom({ creatorId: "carol", name: `Carol's room` }))
     .then(room => {
       carolsRoom = room // we'll want this in the following tests
       t.end()
@@ -969,144 +1038,169 @@ test('[setup] create Carol', t => {
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
-test('subscribe to room implicitly joins', t => {
-  fetchUser(t, 'alice')
-    .then(alice => alice.subscribeToRoom({ roomId: carolsRoom.id })
-      .then(room => {
-        t.equal(room.id, carolsRoom.id)
-        t.true(room.name, `Carol's room`)
-        t.true(
-          any(r => r.id === carolsRoom.id, alice.rooms),
-          `Alice's rooms include Carol's room`
-        )
-        alice.disconnect()
-        t.end()
-      })
-      .catch(endWithErr(t))
+test("subscribe to room implicitly joins", t => {
+  fetchUser(t, "alice")
+    .then(alice =>
+      alice
+        .subscribeToRoom({ roomId: carolsRoom.id })
+        .then(room => {
+          t.equal(room.id, carolsRoom.id)
+          t.true(room.name, `Carol's room`)
+          t.true(
+            any(r => r.id === carolsRoom.id, alice.rooms),
+            `Alice's rooms include Carol's room`,
+          )
+          alice.disconnect()
+          t.end()
+        })
+        .catch(endWithErr(t)),
     )
     .catch(endWithErr(t))
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
 test(`user joined hook [Carol joins Bob's room]`, t => {
-  fetchUser(t, 'alice')
-    .then(alice => alice.subscribeToRoom({
-      roomId: bobsRoom.id,
-      hooks: {
-        onUserJoined: user => {
-          t.equal(user.id, 'carol')
-          t.equal(user.name, 'Carol')
-          alice.disconnect()
-          t.end()
-        }
-      }
-    }))
-    .then(() => server.apiRequest({
-      method: 'PUT',
-      path: `/rooms/${encodeURIComponent(bobsRoom.id)}/users/add`,
-      body: { user_ids: ['carol'] },
-      jwt: server.generateAccessToken({ userId: 'admin', su: true }).token
-    }))
+  fetchUser(t, "alice")
+    .then(alice =>
+      alice.subscribeToRoom({
+        roomId: bobsRoom.id,
+        hooks: {
+          onUserJoined: user => {
+            t.equal(user.id, "carol")
+            t.equal(user.name, "Carol")
+            alice.disconnect()
+            t.end()
+          },
+        },
+      }),
+    )
+    .then(() =>
+      server.apiRequest({
+        method: "PUT",
+        path: `/rooms/${encodeURIComponent(bobsRoom.id)}/users/add`,
+        body: { user_ids: ["carol"] },
+        jwt: server.generateAccessToken({ userId: "admin", su: true }).token,
+      }),
+    )
     .catch(endWithErr(t))
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
-test('user came online hook', t => {
-  fetchUser(t, 'alice')
-    .then(alice => alice.subscribeToRoom({
-      roomId: bobsRoom.id,
-      hooks: {
-        onPresenceChanged: (state, user) => {
-          if (state.previous === 'unknown') {
-            return // ignore the initial state, we only care about the transition
-          }
-          t.equal(state.current, 'online')
-          t.equal(state.previous, 'offline')
-          t.equal(user.id, 'carol')
-          t.equal(user.name, 'Carol')
-          t.equal(user.presence.state, 'online')
-          alice.disconnect()
-          t.end()
-        }
-      }
-    }))
-    .then(() => fetchUser(t, 'carol').then(c => { carol = c }))
+test("user came online hook", t => {
+  fetchUser(t, "alice")
+    .then(alice =>
+      alice.subscribeToRoom({
+        roomId: bobsRoom.id,
+        hooks: {
+          onPresenceChanged: (state, user) => {
+            if (state.previous === "unknown") {
+              return // ignore the initial state, we only care about the transition
+            }
+            t.equal(state.current, "online")
+            t.equal(state.previous, "offline")
+            t.equal(user.id, "carol")
+            t.equal(user.name, "Carol")
+            t.equal(user.presence.state, "online")
+            alice.disconnect()
+            t.end()
+          },
+        },
+      }),
+    )
+    .then(() =>
+      fetchUser(t, "carol").then(c => {
+        carol = c
+      }),
+    )
     .catch(endWithErr(t))
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
-test('user went offline hook', t => {
-  fetchUser(t, 'alice')
-    .then(alice => alice.subscribeToRoom({
-      roomId: bobsRoom.id,
-      hooks: {
-        onPresenceChanged: (state, user) => {
-          if (state.previous === 'unknown') {
-            return // ignore the initial state, we only care about the transition
-          }
-          t.equal(state.current, 'offline')
-          t.equal(state.previous, 'online')
-          t.equal(user.id, 'carol')
-          t.equal(user.name, 'Carol')
-          t.equal(user.presence.state, 'offline')
-          alice.disconnect()
-          t.end()
-        }
-      }
-    }))
+test("user went offline hook", t => {
+  fetchUser(t, "alice")
+    .then(alice =>
+      alice.subscribeToRoom({
+        roomId: bobsRoom.id,
+        hooks: {
+          onPresenceChanged: (state, user) => {
+            if (state.previous === "unknown") {
+              return // ignore the initial state, we only care about the transition
+            }
+            t.equal(state.current, "offline")
+            t.equal(state.previous, "online")
+            t.equal(user.id, "carol")
+            t.equal(user.name, "Carol")
+            t.equal(user.presence.state, "offline")
+            alice.disconnect()
+            t.end()
+          },
+        },
+      }),
+    )
     .then(() => carol.disconnect())
     .catch(endWithErr(t))
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
-test('typing indicators', t => {
+test("typing indicators", t => {
   let started
   Promise.all([
-    fetchUser(t, 'alice')
-    .then(alice => alice.subscribeToRoom({
-      roomId: bobsRoom.id,
-      hooks: {
-        onUserStartedTyping: user => {
-          started = Date.now()
-          t.equal(user.id, 'carol')
-          t.equal(user.name, 'Carol')
+    fetchUser(t, "alice").then(alice =>
+      alice.subscribeToRoom({
+        roomId: bobsRoom.id,
+        hooks: {
+          onUserStartedTyping: user => {
+            started = Date.now()
+            t.equal(user.id, "carol")
+            t.equal(user.name, "Carol")
+          },
+          onUserStoppedTyping: user => {
+            t.equal(user.id, "carol")
+            t.equal(user.name, "Carol")
+            t.true(
+              Date.now() - started > 1000,
+              "fired more than 1s after start",
+            )
+            alice.disconnect()
+            t.end()
+          },
         },
-        onUserStoppedTyping: user => {
-          t.equal(user.id, 'carol')
-          t.equal(user.name, 'Carol')
-          t.true(Date.now() - started > 1000, 'fired more than 1s after start')
-          alice.disconnect()
-          t.end()
-        }
-      }
-    })),
-    fetchUser(t, 'carol')
+      }),
+    ),
+    fetchUser(t, "carol"),
   ])
-    .then(([x, carol]) => carol.isTypingIn({ roomId: bobsRoom.id })
-      .then(() => carol.disconnect()))
+    .then(users =>
+      users[1]
+        .isTypingIn({ roomId: bobsRoom.id })
+        .then(() => users[1].disconnect()),
+    )
     .catch(endWithErr(t))
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
 test(`user left hook [removes Carol from Bob's room]`, t => {
-  fetchUser(t, 'alice')
-    .then(alice => alice.subscribeToRoom({
-      roomId: bobsRoom.id,
-      hooks: {
-        onUserLeft: user => {
-          t.equal(user.id, 'carol')
-          t.equal(user.name, 'Carol')
-          alice.disconnect()
-          t.end()
-        }
-      }
-    }))
-    .then(() => server.apiRequest({
-      method: 'PUT',
-      path: `/rooms/${encodeURIComponent(bobsRoom.id)}/users/remove`,
-      body: { user_ids: ['carol'] },
-      jwt: server.generateAccessToken({ userId: 'admin', su: true }).token
-    }))
+  fetchUser(t, "alice")
+    .then(alice =>
+      alice.subscribeToRoom({
+        roomId: bobsRoom.id,
+        hooks: {
+          onUserLeft: user => {
+            t.equal(user.id, "carol")
+            t.equal(user.name, "Carol")
+            alice.disconnect()
+            t.end()
+          },
+        },
+      }),
+    )
+    .then(() =>
+      server.apiRequest({
+        method: "PUT",
+        path: `/rooms/${encodeURIComponent(bobsRoom.id)}/users/remove`,
+        body: { user_ids: ["carol"] },
+        jwt: server.generateAccessToken({ userId: "admin", su: true }).token,
+      }),
+    )
     .catch(endWithErr(t))
   t.timeoutAfter(TEST_TIMEOUT)
 })
@@ -1115,39 +1209,47 @@ test(`user left hook [removes Carol from Bob's room]`, t => {
 
 test(`new read cursor hook [Bob sets his read cursor in Alice's room]`, t => {
   Promise.all([
-    fetchUser(t, 'bob')
-      .then(bob => bob.joinRoom({ roomId: alicesRoom.id }).then(() => bob)),
-    fetchUser(t, 'alice')
-    .then(alice => alice.subscribeToRoom({
-      roomId: alicesRoom.id,
-      hooks: {
-        onNewReadCursor: cursor => {
-          t.equal(cursor.position, 128)
-          t.equal(cursor.user.name, 'Bob')
-          t.equal(cursor.room.name, `Alice's new room`)
-          alice.disconnect()
-          t.end()
-        }
-      }
-    }))
+    fetchUser(t, "bob").then(bob =>
+      bob.joinRoom({ roomId: alicesRoom.id }).then(() => bob),
+    ),
+    fetchUser(t, "alice").then(alice =>
+      alice.subscribeToRoom({
+        roomId: alicesRoom.id,
+        hooks: {
+          onNewReadCursor: cursor => {
+            t.equal(cursor.position, 128)
+            t.equal(cursor.user.name, "Bob")
+            t.equal(cursor.room.name, `Alice's new room`)
+            alice.disconnect()
+            t.end()
+          },
+        },
+      }),
+    ),
   ])
-    .then(([bob]) => bob.setReadCursor({
-      roomId: alicesRoom.id,
-      position: 128
-    })
-      .then(() => bob.disconnect())
+    .then(([bob]) =>
+      bob
+        .setReadCursor({
+          roomId: alicesRoom.id,
+          position: 128,
+        })
+        .then(() => bob.disconnect()),
     )
     .catch(endWithErr(t))
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
 test(`get another user's read cursor before subscribing to a room fails`, t => {
-  fetchUser(t, 'alice')
+  fetchUser(t, "alice")
     .then(alice => {
-      t.throws(() => alice.readCursor({
-        roomId: alicesRoom.id,
-        userId: 'bob'
-      }), /subscribe/)
+      t.throws(
+        () =>
+          alice.readCursor({
+            roomId: alicesRoom.id,
+            userId: "bob",
+          }),
+        /subscribe/,
+      )
       alice.disconnect()
       t.end()
     })
@@ -1156,18 +1258,17 @@ test(`get another user's read cursor before subscribing to a room fails`, t => {
 })
 
 test(`get another user's read cursor after subscribing to a room`, t => {
-  fetchUser(t, 'alice')
-    .then(alice => alice
-      .subscribeToRoom({ roomId: alicesRoom.id })
-      .then(() => alice)
+  fetchUser(t, "alice")
+    .then(alice =>
+      alice.subscribeToRoom({ roomId: alicesRoom.id }).then(() => alice),
     )
     .then(alice => {
       const cursor = alice.readCursor({
         roomId: alicesRoom.id,
-        userId: 'bob'
+        userId: "bob",
       })
       t.equal(cursor.position, 128)
-      t.equal(cursor.user.name, 'Bob')
+      t.equal(cursor.user.name, "Bob")
       t.equal(cursor.room.name, `Alice's new room`)
       alice.disconnect()
       t.end()
@@ -1176,37 +1277,40 @@ test(`get another user's read cursor after subscribing to a room`, t => {
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
-test('non-admin update room fails gracefully', t => {
-  fetchUser(t, 'alice')
-    .then(alice => alice.updateRoom({
-      roomId: bobsRoom.id,
-      name: `Bob's updated room`
-    })
+test("non-admin update room fails gracefully", t => {
+  fetchUser(t, "alice").then(alice =>
+    alice
+      .updateRoom({
+        roomId: bobsRoom.id,
+        name: `Bob's updated room`,
+      })
       .then(() => t.end(`updateRoom should not resolve`))
       .catch(err => {
-        t.true(toString(err).match(/permission/), 'permission error')
+        t.true(toString(err).match(/permission/), "permission error")
         alice.disconnect()
         t.end()
-      })
-    )
+      }),
+  )
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
-test('non-admin delete room fails gracefully', t => {
-  fetchUser(t, 'alice')
-    .then(alice => alice.deleteRoom({ roomId: bobsRoom.id })
+test("non-admin delete room fails gracefully", t => {
+  fetchUser(t, "alice").then(alice =>
+    alice
+      .deleteRoom({ roomId: bobsRoom.id })
       .then(() => t.end(`deleteRoom should not resolve`))
       .catch(err => {
-        t.true(toString(err).match(/permission/), 'permission error')
+        t.true(toString(err).match(/permission/), "permission error")
         alice.disconnect()
         t.end()
-      })
-    )
+      }),
+  )
   t.timeoutAfter(TEST_TIMEOUT)
 })
 
-test('[setup] promote Alice to admin', t => {
-  server.assignGlobalRoleToUser({ userId: 'alice', roleName: 'admin' })
+test("[setup] promote Alice to admin", t => {
+  server
+    .assignGlobalRoleToUser({ userId: "alice", roleName: "admin" })
     .then(() => t.end())
     .catch(endWithErr(t))
   t.timeoutAfter(TEST_TIMEOUT)
@@ -1214,19 +1318,19 @@ test('[setup] promote Alice to admin', t => {
 
 test(`update room [renames Bob's room]`, t => {
   let alice
-  fetchUser(t, 'alice', {
+  fetchUser(t, "alice", {
     onRoomUpdated: room => {
       t.equal(room.id, bobsRoom.id)
       t.equal(room.name, `Bob's updated room`)
       alice.disconnect()
       t.end()
-    }
+    },
   })
     .then(a => {
       alice = a
       alice.updateRoom({
         roomId: bobsRoom.id,
-        name: `Bob's updated room`
+        name: `Bob's updated room`,
       })
     })
     .then(res => t.equal(res, undefined))
@@ -1236,16 +1340,16 @@ test(`update room [renames Bob's room]`, t => {
 
 test(`delete room [deletes Bob's room]`, t => {
   let alice
-  fetchUser(t, 'alice', {
+  fetchUser(t, "alice", {
     onRoomDeleted: room => {
       t.equal(room.id, bobsRoom.id)
       t.false(
         any(r => r.id === bobsRoom.id, alice.rooms),
-        `alice.rooms doesn't contain Bob's room`
+        `alice.rooms doesn't contain Bob's room`,
       )
       alice.disconnect()
       t.end()
-    }
+    },
   })
     .then(a => {
       alice = a

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,22 @@
 # yarn lockfile v1
 
 
+"@babel/code-frame@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
+  integrity sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==
+  dependencies:
+    "@babel/highlight" "^7.0.0"
+
+"@babel/highlight@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0.tgz#f710c38c8d458e6dd9a201afb637fcb781ce99e4"
+  integrity sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^4.0.0"
+
 "@juliangruber/tap-finished@0.0.2":
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/@juliangruber/tap-finished/-/tap-finished-0.0.2.tgz#a9aad63d5e4425ff8a6d9a6a94ab287a1b595dbe"
@@ -42,12 +58,10 @@ acorn-dynamic-import@^4.0.0:
   resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz#482210140582a36b83c3e342e1cfebcaa9240948"
   integrity sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==
 
-acorn-jsx@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
-  integrity sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=
-  dependencies:
-    acorn "^3.0.4"
+acorn-jsx@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.0.tgz#958584ddb60990c02c97c1bd9d521fce433bb101"
+  integrity sha512-XkB50fn0MURDyww9+UYL3c1yLbOBz0ZFvrdYlGB8l+Ije1oSC75qAqrzSPjYQbdnQUzhlUGNKuesryAv0gxZOg==
 
 acorn-node@^1.2.0, acorn-node@^1.3.0, acorn-node@^1.5.2:
   version "1.6.2"
@@ -64,12 +78,7 @@ acorn-walk@^6.1.0:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.1.0.tgz#c957f4a1460da46af4a0388ce28b4c99355b0cbc"
   integrity sha512-ugTb7Lq7u4GfWSqqpwE0bGyoBZNMTok/zDBXxfEG0QM50jNlGhIWjRC1pPN7bvV1anhF+bs+/gNcRw+o55Evbg==
 
-acorn@^3.0.4:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
-  integrity sha1-ReN/s56No/JbruP/U2niu18iAXo=
-
-acorn@^5.2.1, acorn@^5.5.0:
+acorn@^5.2.1:
   version "5.7.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
   integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
@@ -78,19 +87,6 @@ acorn@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.0.2.tgz#6a459041c320ab17592c6317abbfdf4bbaa98ca4"
   integrity sha512-GXmKIvbrN3TV7aVqAzVFaMW8F8wzVX7voEBRO3bDA64+EX37YSayggRJP5Xig6HYHBkWKpFg9W5gg6orklubhg==
-
-ajv-keywords@^1.0.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
-  integrity sha1-MU3QpLM2j609/NxU7eYXG4htrzw=
-
-ajv@^4.7.0:
-  version "4.11.8"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
-  integrity sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=
-  dependencies:
-    co "^4.6.0"
-    json-stable-stringify "^1.0.1"
 
 ajv@^5.3.0:
   version "5.5.2"
@@ -102,10 +98,20 @@ ajv@^5.3.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
 
-ansi-escapes@^1.1.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
-  integrity sha1-06ioOzGapneTZisT52HHkRQiMG4=
+ajv@^6.5.3:
+  version "6.5.4"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.5.4.tgz#247d5274110db653706b550fcc2b797ca28cfc59"
+  integrity sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ansi-escapes@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
+  integrity sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -221,14 +227,6 @@ array-unique@^0.3.2:
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
 
-array.prototype.find@^2.0.1:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/array.prototype.find/-/array.prototype.find-2.0.4.tgz#556a5c5362c08648323ddaeb9de9d14bc1864c90"
-  integrity sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=
-  dependencies:
-    define-properties "^1.1.2"
-    es-abstract "^1.7.0"
-
 arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
@@ -319,7 +317,7 @@ babel-cli@^6.26.0:
   optionalDependencies:
     chokidar "^1.6.1"
 
-babel-code-frame@^6.16.0, babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
+babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
   integrity sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=
@@ -352,16 +350,6 @@ babel-core@^6.26.0:
     private "^0.1.8"
     slash "^1.0.0"
     source-map "^0.5.7"
-
-babel-eslint@^7.0.0:
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-7.2.3.tgz#b2fe2d80126470f5c19442dc757253a897710827"
-  integrity sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=
-  dependencies:
-    babel-code-frame "^6.22.0"
-    babel-traverse "^6.23.1"
-    babel-types "^6.23.0"
-    babylon "^6.17.0"
 
 babel-generator@^6.26.0:
   version "6.26.1"
@@ -516,11 +504,6 @@ babel-plugin-syntax-async-functions@^6.8.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
   integrity sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=
 
-babel-plugin-syntax-class-properties@^6.8.0:
-  version "6.13.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
-  integrity sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=
-
 babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
@@ -544,16 +527,6 @@ babel-plugin-transform-async-to-generator@^6.22.0:
     babel-helper-remap-async-to-generator "^6.24.1"
     babel-plugin-syntax-async-functions "^6.8.0"
     babel-runtime "^6.22.0"
-
-babel-plugin-transform-class-properties@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz#6a79763ea61d33d36f37b611aa9def81a81b46ac"
-  integrity sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=
-  dependencies:
-    babel-helper-function-name "^6.24.1"
-    babel-plugin-syntax-class-properties "^6.8.0"
-    babel-runtime "^6.22.0"
-    babel-template "^6.24.1"
 
 babel-plugin-transform-es2015-arrow-functions@^6.22.0:
   version "6.22.0"
@@ -854,7 +827,7 @@ babel-template@^6.24.1, babel-template@^6.26.0:
     babylon "^6.18.0"
     lodash "^4.17.4"
 
-babel-traverse@^6.23.1, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
+babel-traverse@^6.24.1, babel-traverse@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
   integrity sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=
@@ -869,7 +842,7 @@ babel-traverse@^6.23.1, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
     invariant "^2.2.2"
     lodash "^4.17.4"
 
-babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24.1, babel-types@^6.26.0:
+babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   integrity sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=
@@ -884,7 +857,7 @@ babelify@^8.0.0:
   resolved "https://registry.yarnpkg.com/babelify/-/babelify-8.0.0.tgz#6f60f5f062bfe7695754ef2403b842014a580ed3"
   integrity sha512-xVr63fKEvMWUrrIbqlHYsMcc5Zdw4FSVesAHgkgajyCE1W8gbm9rbMakqavhxKvikGYMhEcqxTwB/gQmQ6lBtw==
 
-babylon@^6.17.0, babylon@^6.18.0:
+babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
   integrity sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==
@@ -1177,7 +1150,7 @@ buffer@^5.0.2:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
 
-builtin-modules@^1.0.0, builtin-modules@^1.1.1:
+builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
   integrity sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=
@@ -1252,7 +1225,7 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
+chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
@@ -1263,7 +1236,7 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.3.0:
+chalk@^2.0.0, chalk@^2.1.0, chalk@^2.3.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   integrity sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==
@@ -1271,6 +1244,11 @@ chalk@^2.3.0:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
+
+chardet@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
+  integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
 chokidar@^1.6.1:
   version "1.7.0"
@@ -1316,12 +1294,12 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-cli-cursor@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
-  integrity sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=
+cli-cursor@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
+  integrity sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=
   dependencies:
-    restore-cursor "^1.0.1"
+    restore-cursor "^2.0.0"
 
 cli-width@^2.0.0:
   version "2.2.0"
@@ -1400,7 +1378,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concat-stream@1.6.2, concat-stream@^1.5.0, concat-stream@^1.5.2, concat-stream@^1.6.1, concat-stream@~1.6.0:
+concat-stream@1.6.2, concat-stream@^1.5.0, concat-stream@^1.6.1, concat-stream@~1.6.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
@@ -1440,11 +1418,6 @@ constants-browserify@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
   integrity sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=
-
-contains-path@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
-  integrity sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=
 
 content-type@~1.0.4:
   version "1.0.4"
@@ -1509,6 +1482,17 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-spawn@^6.0.5:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
 crypto-browserify@^3.0.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-3.12.0.tgz#396cf9f3137f03e4b8e532c58f698254e00f80ec"
@@ -1545,13 +1529,6 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-d@1:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
-  integrity sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=
-  dependencies:
-    es5-ext "^0.10.9"
-
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -1564,17 +1541,19 @@ date-now@^0.1.4:
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
   integrity sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=
 
-debug-log@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
-  integrity sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=
-
-debug@2.6.9, debug@^2.1.1, debug@^2.1.2, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.1, debug@^2.6.8, debug@^2.6.9:
+debug@2.6.9, debug@^2.1.2, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.1, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
+
+debug@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87"
+  integrity sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==
+  dependencies:
+    ms "^2.1.1"
 
 decamelize@^1.1.2:
   version "1.2.0"
@@ -1634,18 +1613,6 @@ defined@^1.0.0, defined@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
   integrity sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=
-
-deglob@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/deglob/-/deglob-2.1.1.tgz#d268e168727799862e8eac07042e165957c1f3be"
-  integrity sha512-2kjwuGGonL7gWE1XU4Fv79+vVzpoQCl0V+boMwWtOQJV2AGDabCwez++nB1Nli/8BabAfZQ/UuHPlp6AymKdWw==
-  dependencies:
-    find-root "^1.0.0"
-    glob "^7.0.5"
-    ignore "^3.0.9"
-    pkg-config "^1.1.0"
-    run-parallel "^1.1.2"
-    uniq "^1.0.1"
 
 del@^2.0.2:
   version "2.2.2"
@@ -1731,15 +1698,7 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
-doctrine@1.5.0, doctrine@^1.2.2:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
-  integrity sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=
-  dependencies:
-    esutils "^2.0.2"
-    isarray "^1.0.0"
-
-doctrine@^2.0.0:
+doctrine@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
   integrity sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
@@ -1876,14 +1835,14 @@ enstore@^1.0.1:
   dependencies:
     monotonic-timestamp "0.0.8"
 
-error-ex@^1.2.0, error-ex@^1.3.1:
+error-ex@^1.2.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.5.0, es-abstract@^1.7.0:
+es-abstract@^1.5.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.12.0.tgz#9dbbdd27c6856f0001421ca18782d786bf8a6165"
   integrity sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==
@@ -1903,215 +1862,107 @@ es-to-primitive@^1.1.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-es5-ext@^0.10.14, es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
-  version "0.10.46"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.46.tgz#efd99f67c5a7ec789baa3daa7f79870388f7f572"
-  integrity sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==
-  dependencies:
-    es6-iterator "~2.0.3"
-    es6-symbol "~3.1.1"
-    next-tick "1"
-
-es6-iterator@^2.0.1, es6-iterator@~2.0.1, es6-iterator@~2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
-  integrity sha1-p96IkUGgWpSwhUQDstCg+/qY87c=
-  dependencies:
-    d "1"
-    es5-ext "^0.10.35"
-    es6-symbol "^3.1.1"
-
-es6-map@^0.1.3:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/es6-map/-/es6-map-0.1.5.tgz#9136e0503dcc06a301690f0bb14ff4e364e949f0"
-  integrity sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
-    es6-iterator "~2.0.1"
-    es6-set "~0.1.5"
-    es6-symbol "~3.1.1"
-    event-emitter "~0.3.5"
-
 es6-promise@^4.0.5:
   version "4.2.5"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.5.tgz#da6d0d5692efb461e082c14817fe2427d8f5d054"
   integrity sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==
-
-es6-set@~0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.5.tgz#d2b3ec5d4d800ced818db538d28974db0a73ccb1"
-  integrity sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
-    es6-iterator "~2.0.1"
-    es6-symbol "3.1.1"
-    event-emitter "~0.3.5"
-
-es6-symbol@3.1.1, es6-symbol@^3.1.1, es6-symbol@~3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
-  integrity sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
-
-es6-weak-map@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.2.tgz#5e3ab32251ffd1538a1f8e5ffa1357772f92d96f"
-  integrity sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=
-  dependencies:
-    d "1"
-    es5-ext "^0.10.14"
-    es6-iterator "^2.0.1"
-    es6-symbol "^3.1.1"
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-escope@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/escope/-/escope-3.6.0.tgz#e01975e812781a163a6dadfdd80398dc64c889c3"
-  integrity sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=
+eslint-config-prettier@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-3.1.0.tgz#2c26d2cdcfa3a05f0642cd7e6e4ef3316cdabfa2"
+  integrity sha512-QYGfmzuc4q4J6XIhlp8vRKdI/fI0tQfQPy1dME3UOLprE+v4ssH/3W9LM2Q7h5qBcy5m0ehCrBDU2YF8q6OY8w==
   dependencies:
-    es6-map "^0.1.3"
-    es6-weak-map "^2.0.1"
+    get-stdin "^6.0.0"
+
+eslint-plugin-prettier@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.0.0.tgz#f6b823e065f8c36529918cdb766d7a0e975ec30c"
+  integrity sha512-4g11opzhqq/8+AMmo5Vc2Gn7z9alZ4JqrbZ+D4i8KlSyxeQhZHlmIrY8U9Akf514MoEhogPa87Jgkq87aZ2Ohw==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
+eslint-scope@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.0.tgz#50bf3071e9338bcdc43331794a0cb533f0136172"
+  integrity sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==
+  dependencies:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-config-standard-jsx@4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/eslint-config-standard-jsx/-/eslint-config-standard-jsx-4.0.2.tgz#009e53c4ddb1e9ee70b4650ffe63a7f39f8836e1"
-  integrity sha512-F8fRh2WFnTek7dZH9ZaE0PCBwdVGkwVWZmizla/DDNOmg7Tx6B/IlK5+oYpiX29jpu73LszeJj5i1axEZv6VMw==
+eslint-utils@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.3.1.tgz#9a851ba89ee7c460346f97cf8939c7298827e512"
+  integrity sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==
 
-eslint-config-standard@10.2.1:
-  version "10.2.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-10.2.1.tgz#c061e4d066f379dc17cd562c64e819b4dd454591"
-  integrity sha1-wGHk0GbzedwXzVYsZOgZtN1FRZE=
+eslint-visitor-keys@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
+  integrity sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
 
-eslint-import-resolver-node@^0.2.0:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz#5add8106e8c928db2cba232bcd9efa846e3da16c"
-  integrity sha1-Wt2BBujJKNssuiMrzZ76hG49oWw=
+eslint@^5.8.0:
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.8.0.tgz#91fbf24f6e0471e8fdf681a4d9dd1b2c9f28309b"
+  integrity sha512-Zok6Bru3y2JprqTNm14mgQ15YQu/SMDkWdnmHfFg770DIUlmMFd/gqqzCHekxzjHZJxXv3tmTpH0C1icaYJsRQ==
   dependencies:
-    debug "^2.2.0"
-    object-assign "^4.0.1"
-    resolve "^1.1.6"
-
-eslint-module-utils@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz#b270362cd88b1a48ad308976ce7fa54e98411746"
-  integrity sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=
-  dependencies:
-    debug "^2.6.8"
-    pkg-dir "^1.0.0"
-
-eslint-plugin-import@~2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.2.0.tgz#72ba306fad305d67c4816348a4699a4229ac8b4e"
-  integrity sha1-crowb60wXWfEgWNIpGmaQimsi04=
-  dependencies:
-    builtin-modules "^1.1.1"
-    contains-path "^0.1.0"
-    debug "^2.2.0"
-    doctrine "1.5.0"
-    eslint-import-resolver-node "^0.2.0"
-    eslint-module-utils "^2.0.0"
-    has "^1.0.1"
-    lodash.cond "^4.3.0"
-    minimatch "^3.0.3"
-    pkg-up "^1.0.0"
-
-eslint-plugin-node@~4.2.2:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-4.2.3.tgz#c04390ab8dbcbb6887174023d6f3a72769e63b97"
-  integrity sha512-vIUQPuwbVYdz/CYnlTLsJrRy7iXHQjdEe5wz0XhhdTym3IInM/zZLlPf9nZ2mThsH0QcsieCOWs2vOeCy/22LQ==
-  dependencies:
-    ignore "^3.0.11"
-    minimatch "^3.0.2"
-    object-assign "^4.0.1"
-    resolve "^1.1.7"
-    semver "5.3.0"
-
-eslint-plugin-promise@~3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.5.0.tgz#78fbb6ffe047201627569e85a6c5373af2a68fca"
-  integrity sha1-ePu2/+BHIBYnVp6FpsU3OvKmj8o=
-
-eslint-plugin-react@~6.10.0:
-  version "6.10.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz#c5435beb06774e12c7db2f6abaddcbf900cd3f78"
-  integrity sha1-xUNb6wZ3ThLH2y9qut3L+QDNP3g=
-  dependencies:
-    array.prototype.find "^2.0.1"
-    doctrine "^1.2.2"
-    has "^1.0.1"
-    jsx-ast-utils "^1.3.4"
-    object.assign "^4.0.4"
-
-eslint-plugin-standard@~3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz#34d0c915b45edc6f010393c7eef3823b08565cf2"
-  integrity sha1-NNDJFbRe3G8BA5PH7vOCOwhWXPI=
-
-eslint@~3.19.0:
-  version "3.19.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.19.0.tgz#c8fc6201c7f40dd08941b87c085767386a679acc"
-  integrity sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=
-  dependencies:
-    babel-code-frame "^6.16.0"
-    chalk "^1.1.3"
-    concat-stream "^1.5.2"
-    debug "^2.1.1"
-    doctrine "^2.0.0"
-    escope "^3.6.0"
-    espree "^3.4.0"
-    esquery "^1.0.0"
-    estraverse "^4.2.0"
+    "@babel/code-frame" "^7.0.0"
+    ajv "^6.5.3"
+    chalk "^2.1.0"
+    cross-spawn "^6.0.5"
+    debug "^4.0.1"
+    doctrine "^2.1.0"
+    eslint-scope "^4.0.0"
+    eslint-utils "^1.3.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^4.0.0"
+    esquery "^1.0.1"
     esutils "^2.0.2"
     file-entry-cache "^2.0.0"
-    glob "^7.0.3"
-    globals "^9.14.0"
-    ignore "^3.2.0"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^11.7.0"
+    ignore "^4.0.6"
     imurmurhash "^0.1.4"
-    inquirer "^0.12.0"
-    is-my-json-valid "^2.10.0"
-    is-resolvable "^1.0.0"
-    js-yaml "^3.5.1"
-    json-stable-stringify "^1.0.0"
+    inquirer "^6.1.0"
+    is-resolvable "^1.1.0"
+    js-yaml "^3.12.0"
+    json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.3.0"
-    lodash "^4.0.0"
-    mkdirp "^0.5.0"
+    lodash "^4.17.5"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
     natural-compare "^1.4.0"
     optionator "^0.8.2"
-    path-is-inside "^1.0.1"
-    pluralize "^1.2.1"
-    progress "^1.1.8"
-    require-uncached "^1.0.2"
-    shelljs "^0.7.5"
-    strip-bom "^3.0.0"
-    strip-json-comments "~2.0.1"
-    table "^3.7.8"
-    text-table "~0.2.0"
-    user-home "^2.0.0"
+    path-is-inside "^1.0.2"
+    pluralize "^7.0.0"
+    progress "^2.0.0"
+    regexpp "^2.0.1"
+    require-uncached "^1.0.3"
+    semver "^5.5.1"
+    strip-ansi "^4.0.0"
+    strip-json-comments "^2.0.1"
+    table "^5.0.2"
+    text-table "^0.2.0"
 
-espree@^3.4.0:
-  version "3.5.4"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.4.tgz#b0f447187c8a8bed944b815a660bddf5deb5d1a7"
-  integrity sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==
+espree@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-4.1.0.tgz#728d5451e0fd156c04384a7ad89ed51ff54eb25f"
+  integrity sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==
   dependencies:
-    acorn "^5.5.0"
-    acorn-jsx "^3.0.0"
+    acorn "^6.0.2"
+    acorn-jsx "^5.0.0"
+    eslint-visitor-keys "^1.0.0"
 
 esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.0.0:
+esquery@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
   integrity sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==
@@ -2125,7 +1976,7 @@ esrecurse@^4.1.0:
   dependencies:
     estraverse "^4.1.0"
 
-estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
+estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
   integrity sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=
@@ -2145,14 +1996,6 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
   integrity sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=
 
-event-emitter@~0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
-  integrity sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
-
 events@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
@@ -2165,11 +2008,6 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   dependencies:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
-
-exit-hook@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
-  integrity sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=
 
 expand-brackets@^0.1.4:
   version "0.1.5"
@@ -2223,6 +2061,15 @@ extend@~3.0.2:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
+external-editor@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.0.3.tgz#5866db29a97826dbe4bf3afd24070ead9ea43a27"
+  integrity sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==
+  dependencies:
+    chardet "^0.7.0"
+    iconv-lite "^0.4.24"
+    tmp "^0.0.33"
+
 extglob@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
@@ -2269,6 +2116,16 @@ fast-deep-equal@^1.0.0:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
   integrity sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=
 
+fast-deep-equal@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+  integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
+
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
+
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
@@ -2286,13 +2143,12 @@ fd-slicer@~1.0.1:
   dependencies:
     pend "~1.2.0"
 
-figures@^1.3.5:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
-  integrity sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=
+figures@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
+  integrity sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
   dependencies:
     escape-string-regexp "^1.0.5"
-    object-assign "^4.1.0"
 
 file-entry-cache@^2.0.0:
   version "2.0.0"
@@ -2328,11 +2184,6 @@ fill-range@^4.0.0:
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
 
-find-root@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
-  integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
-
 find-up@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
@@ -2340,13 +2191,6 @@ find-up@^1.0.0:
   dependencies:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
-
-find-up@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
-  integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
-  dependencies:
-    locate-path "^2.0.0"
 
 flat-cache@^1.2.1:
   version "1.3.0"
@@ -2439,6 +2283,11 @@ function-bind@^1.0.2, function-bind@^1.1.1, function-bind@~1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+functional-red-black-tree@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+  integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -2453,20 +2302,6 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
-generate-function@^2.0.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/generate-function/-/generate-function-2.3.1.tgz#f069617690c10c868e73b8465746764f97c3479f"
-  integrity sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==
-  dependencies:
-    is-property "^1.0.2"
-
-generate-object-property@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/generate-object-property/-/generate-object-property-1.2.0.tgz#9c0e1c40308ce804f4783618b937fa88f99d50d0"
-  integrity sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=
-  dependencies:
-    is-property "^1.0.0"
-
 get-assigned-identifiers@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz#6dbf411de648cbaf8d9169ebb0d2d576191e2ff1"
@@ -2477,10 +2312,10 @@ get-stdin@^4.0.1:
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
   integrity sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=
 
-get-stdin@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
-  integrity sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=
+get-stdin@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
+  integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
@@ -2509,7 +2344,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.0, glob@^7.1.2, glob@~7.1.2:
+glob@^7.0.3, glob@^7.0.5, glob@^7.1.0, glob@^7.1.2, glob@~7.1.2:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
@@ -2521,7 +2356,12 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.0, glob@^7.1.2, glob@~7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^9.14.0, globals@^9.18.0:
+globals@^11.7.0:
+  version "11.8.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.8.0.tgz#c1ef45ee9bed6badf0663c5cb90e8d1adec1321d"
+  integrity sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==
+
+globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
   integrity sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==
@@ -2736,7 +2576,7 @@ iconv-lite@0.4.23:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@^0.4.4:
+iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -2755,10 +2595,10 @@ ignore-walk@^3.0.1:
   dependencies:
     minimatch "^3.0.4"
 
-ignore@^3.0.11, ignore@^3.0.9, ignore@^3.2.0:
-  version "3.3.10"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
-  integrity sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==
+ignore@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
+  integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -2807,23 +2647,23 @@ inline-source-map@~0.6.0:
   dependencies:
     source-map "~0.5.3"
 
-inquirer@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-0.12.0.tgz#1ef2bfd63504df0bc75785fff8c2c41df12f077e"
-  integrity sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=
+inquirer@^6.1.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.0.tgz#51adcd776f661369dc1e894859c2560a224abdd8"
+  integrity sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==
   dependencies:
-    ansi-escapes "^1.1.0"
-    ansi-regex "^2.0.0"
-    chalk "^1.0.0"
-    cli-cursor "^1.0.1"
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
     cli-width "^2.0.0"
-    figures "^1.3.5"
-    lodash "^4.3.0"
-    readline2 "^1.0.1"
-    run-async "^0.1.0"
-    rx-lite "^3.1.2"
-    string-width "^1.0.1"
-    strip-ansi "^3.0.0"
+    external-editor "^3.0.0"
+    figures "^2.0.0"
+    lodash "^4.17.10"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^6.1.0"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
     through "^2.3.6"
 
 insert-module-globals@^7.0.0:
@@ -2841,11 +2681,6 @@ insert-module-globals@^7.0.0:
     through2 "^2.0.0"
     undeclared-identifiers "^1.1.2"
     xtend "^4.0.0"
-
-interpret@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
-  integrity sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=
 
 invariant@^2.2.2:
   version "2.2.4"
@@ -2994,22 +2829,6 @@ is-module@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
   integrity sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=
 
-is-my-ip-valid@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz#7b351b8e8edd4d3995d4d066680e664d94696824"
-  integrity sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==
-
-is-my-json-valid@^2.10.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz#8fd6e40363cd06b963fa877d444bfb5eddc62175"
-  integrity sha512-mG0f/unGX1HZ5ep4uhRaPOS8EkAY8/j6mDRMJrutq4CqhoJWYp7qAlonIPy3TV7p3ju4TK9fo/PbnoksWmsp5Q==
-  dependencies:
-    generate-function "^2.0.0"
-    generate-object-property "^1.1.0"
-    is-my-ip-valid "^1.0.0"
-    jsonpointer "^4.0.0"
-    xtend "^4.0.0"
-
 is-number@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
@@ -3065,10 +2884,10 @@ is-primitive@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
   integrity sha1-IHurkWOEmcB7Kt8kCkGochADRXU=
 
-is-property@^1.0.0, is-property@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
-  integrity sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=
+is-promise@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+  integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
 
 is-regex@^1.0.4:
   version "1.0.4"
@@ -3077,7 +2896,7 @@ is-regex@^1.0.4:
   dependencies:
     has "^1.0.1"
 
-is-resolvable@^1.0.0:
+is-resolvable@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
   integrity sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==
@@ -3109,7 +2928,7 @@ isarray@0.0.1, isarray@~0.0.1:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
   integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
-isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
+isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
@@ -3118,6 +2937,11 @@ isarray@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.4.tgz#38e7bcbb0f3ba1b7933c86ba1894ddfc3781bbb7"
   integrity sha512-GMxXOiUirWg1xTKRipM0Ek07rX+ubx4nNVElTJdNLYmNO/2YrDkgJGw9CljXn+r4EWiDQg/8lsRdHyg2PJuUaA==
+
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+  integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
 isobject@^2.0.0:
   version "2.1.0"
@@ -3136,7 +2960,7 @@ isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
-"js-tokens@^3.0.0 || ^4.0.0":
+"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
@@ -3146,7 +2970,7 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@^3.5.1:
+js-yaml@^3.12.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
   integrity sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==
@@ -3169,27 +2993,25 @@ jsesc@~0.5.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
   integrity sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=
 
-json-parse-better-errors@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
-  integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
-
 json-schema-traverse@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
   integrity sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=
+
+json-schema-traverse@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
+  integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
   integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
 
-json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
+json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
-  integrity sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=
-  dependencies:
-    jsonify "~0.0.0"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+  integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
 json-stable-stringify@~0.0.0:
   version "0.0.1"
@@ -3225,11 +3047,6 @@ jsonparse@^1.2.0:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
-jsonpointer@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
-  integrity sha1-T9kss04OnbPInIYi7PUfm5eMbLk=
-
 jsonwebtoken@^8.3.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.3.0.tgz#056c90eee9a65ed6e6c72ddb0a1d325109aaf643"
@@ -3254,11 +3071,6 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
-
-jsx-ast-utils@^1.3.4:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz#3867213e8dd79bf1e8f2300c0cfc1efb182c0df1"
-  integrity sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=
 
 jwa@^1.1.5:
   version "1.1.6"
@@ -3336,29 +3148,6 @@ load-json-file@^1.0.0:
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
 
-load-json-file@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
-  integrity sha1-L19Fq5HjMhYjT9U62rZo607AmTs=
-  dependencies:
-    graceful-fs "^4.1.2"
-    parse-json "^4.0.0"
-    pify "^3.0.0"
-    strip-bom "^3.0.0"
-
-locate-path@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
-  integrity sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=
-  dependencies:
-    p-locate "^2.0.0"
-    path-exists "^3.0.0"
-
-lodash.cond@^4.3.0:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
-  integrity sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=
-
 lodash.includes@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
@@ -3399,7 +3188,7 @@ lodash.once@^4.0.0:
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
-lodash@^4.0.0, lodash@^4.17.4, lodash@^4.3.0:
+lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -3546,6 +3335,11 @@ mime@^1.2.11, mime@^1.6.0:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
+mimic-fn@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
+  integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
+
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
@@ -3556,7 +3350,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
+minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -3659,10 +3453,10 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
-mute-stream@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
-  integrity sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=
+mute-stream@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+  integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
 nan@^2.9.2:
   version "2.11.1"
@@ -3700,10 +3494,10 @@ needle@^2.2.1:
     iconv-lite "^0.4.4"
     sax "^1.2.4"
 
-next-tick@1:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
-  integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
+nice-try@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
+  integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
 node-pre-gyp@^0.10.0:
   version "0.10.3"
@@ -3811,7 +3605,7 @@ object-inspect@~1.6.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.6.0.tgz#c70b6cbf72f274aab4c34c0c82f5167bf82cf15b"
   integrity sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==
 
-object-keys@^1.0.11, object-keys@^1.0.12:
+object-keys@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
   integrity sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==
@@ -3827,16 +3621,6 @@ object-visit@^1.0.0:
   integrity sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=
   dependencies:
     isobject "^3.0.0"
-
-object.assign@^4.0.4:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
-  integrity sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==
-  dependencies:
-    define-properties "^1.1.2"
-    function-bind "^1.1.1"
-    has-symbols "^1.0.0"
-    object-keys "^1.0.11"
 
 object.omit@^2.0.0:
   version "2.0.1"
@@ -3867,10 +3651,12 @@ once@^1.3.0, once@^1.3.3:
   dependencies:
     wrappy "1"
 
-onetime@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
-  integrity sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=
+onetime@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
+  integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
+  dependencies:
+    mimic-fn "^1.0.0"
 
 optimist@^0.6.1, optimist@~0.6.1:
   version "0.6.1"
@@ -3907,7 +3693,7 @@ os-homedir@^1.0.0:
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
   integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
 
-os-tmpdir@^1.0.0, os-tmpdir@^1.0.1:
+os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
@@ -3928,25 +3714,6 @@ output-file-sync@^1.1.2:
     graceful-fs "^4.1.4"
     mkdirp "^0.5.1"
     object-assign "^4.1.0"
-
-p-limit@^1.1.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
-  integrity sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==
-  dependencies:
-    p-try "^1.0.0"
-
-p-locate@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
-  integrity sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=
-  dependencies:
-    p-limit "^1.1.0"
-
-p-try@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
-  integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
 
 pako@~1.0.5:
   version "1.0.6"
@@ -3988,14 +3755,6 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
-parse-json@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
-  integrity sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=
-  dependencies:
-    error-ex "^1.3.1"
-    json-parse-better-errors "^1.0.1"
-
 pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
@@ -4013,20 +3772,20 @@ path-exists@^2.0.0, path-exists@^2.1.0:
   dependencies:
     pinkie-promise "^2.0.0"
 
-path-exists@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
-  integrity sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
-
 path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
-path-is-inside@^1.0.1:
+path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
   integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
+
+path-key@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
+  integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
 path-parse@^1.0.5:
   version "1.0.6"
@@ -4080,11 +3839,6 @@ pify@^2.0.0, pify@^2.3.0:
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
   integrity sha1-7RQaasBDqEnqWISY59yosVMw6Qw=
 
-pify@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
-  integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
-
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
@@ -4097,37 +3851,6 @@ pinkie@^2.0.0:
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
-pkg-conf@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/pkg-conf/-/pkg-conf-2.1.0.tgz#2126514ca6f2abfebd168596df18ba57867f0058"
-  integrity sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=
-  dependencies:
-    find-up "^2.0.0"
-    load-json-file "^4.0.0"
-
-pkg-config@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/pkg-config/-/pkg-config-1.1.1.tgz#557ef22d73da3c8837107766c52eadabde298fe4"
-  integrity sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=
-  dependencies:
-    debug-log "^1.0.0"
-    find-root "^1.0.0"
-    xtend "^4.0.1"
-
-pkg-dir@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4"
-  integrity sha1-ektQio1bstYp1EcFb/TpyTFM89Q=
-  dependencies:
-    find-up "^1.0.0"
-
-pkg-up@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-1.0.0.tgz#3e08fb461525c4421624a33b9f7e6d0af5b05a26"
-  integrity sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=
-  dependencies:
-    find-up "^1.0.0"
-
 plist@0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/plist/-/plist-0.2.1.tgz#f3a3de07885d773e66d8a96782f1bec28cf2b2d0"
@@ -4135,10 +3858,10 @@ plist@0.2.1:
   dependencies:
     sax "0.1.x"
 
-pluralize@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
-  integrity sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=
+pluralize@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
+  integrity sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==
 
 posix-character-classes@^0.1.0:
   version "0.1.1"
@@ -4154,6 +3877,18 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
+
+prettier@1.14.3:
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.3.tgz#90238dd4c0684b7edce5f83b0fb7328e48bd0895"
+  integrity sha512-qZDVnCrnpsRJJq5nSsiHCE3BYMED2OtsI+cmzIzF1QIfqm5ALf8tEJcO27zV1gKNKRPdhjO0dNWnrzssDQ1tFg==
 
 pretty-bytes@^1.0.2:
   version "1.0.4"
@@ -4191,10 +3926,10 @@ progress-stream@^1.1.0:
     speedometer "~0.1.2"
     through2 "~0.2.3"
 
-progress@^1.1.8:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
-  integrity sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=
+progress@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.1.tgz#c9242169342b1c29d275889c95734621b1952e31"
+  integrity sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==
 
 psl@^1.1.24:
   version "1.1.29"
@@ -4222,6 +3957,11 @@ punycode@^1.3.2, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
+
+punycode@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
 pusher-platform-node@~0.13.0:
   version "0.13.2"
@@ -4392,22 +4132,6 @@ readdirp@^2.0.0:
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
 
-readline2@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/readline2/-/readline2-1.0.1.tgz#41059608ffc154757b715d9989d199ffbf372e35"
-  integrity sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=
-  dependencies:
-    code-point-at "^1.0.0"
-    is-fullwidth-code-point "^1.0.0"
-    mute-stream "0.0.5"
-
-rechoir@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
-  integrity sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=
-  dependencies:
-    resolve "^1.1.6"
-
 redent@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/redent/-/redent-1.0.0.tgz#cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde"
@@ -4454,6 +4178,11 @@ regex-not@^1.0.0, regex-not@^1.0.2:
   dependencies:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
+
+regexpp@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
+  integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
 
 regexpu-core@^2.0.0:
   version "2.0.0"
@@ -4524,7 +4253,7 @@ request@^2.45.0, request@^2.81.0:
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
 
-require-uncached@^1.0.2:
+require-uncached@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
   integrity sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=
@@ -4547,7 +4276,7 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@^1.1.3, resolve@^1.1.4, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.4.0:
+resolve@^1.1.3, resolve@^1.1.4, resolve@^1.1.6, resolve@^1.4.0:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   integrity sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==
@@ -4561,13 +4290,13 @@ resolve@~1.7.1:
   dependencies:
     path-parse "^1.0.5"
 
-restore-cursor@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
-  integrity sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=
+restore-cursor@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
+  integrity sha1-n37ih/gv0ybU/RYpI9YhKe7g368=
   dependencies:
-    exit-hook "^1.0.0"
-    onetime "^1.0.0"
+    onetime "^2.0.0"
+    signal-exit "^3.0.2"
 
 resumer@~0.0.0:
   version "0.0.0"
@@ -4665,22 +4394,19 @@ rollup@^0.55.3:
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.55.5.tgz#2f88c300f7cf24b5ec2dca8a6aba73b04e087e93"
   integrity sha512-2hke9NOy332kxvnmMQOgl7DHm94zihNyYJNd8ZLWo4U0EjFvjUkeWa0+ge+70bTg+mY0xJ7NUsf5kIhDtrGrtA==
 
-run-async@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389"
-  integrity sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=
+run-async@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
+  integrity sha1-A3GrSuC91yDUFm19/aZP96RFpsA=
   dependencies:
-    once "^1.3.0"
+    is-promise "^2.1.0"
 
-run-parallel@^1.1.2:
-  version "1.1.9"
-  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
-  integrity sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==
-
-rx-lite@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
-  integrity sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=
+rxjs@^6.1.0:
+  version "6.3.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.3.tgz#3c6a7fa420e844a81390fb1158a9ec614f4bad55"
+  integrity sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==
+  dependencies:
+    tslib "^1.9.0"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
@@ -4709,15 +4435,10 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.5.0, semver@^5.5.1:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
-
-semver@5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
-  integrity sha1-myzl094C0XxgEq0yaqa00M9U+U8=
 
 server-destroy@^1.0.1:
   version "1.0.1"
@@ -4770,6 +4491,18 @@ shasum@^1.0.0:
     json-stable-stringify "~0.0.0"
     sha.js "~2.4.4"
 
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  integrity sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=
+  dependencies:
+    shebang-regex "^1.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+  integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
 shell-quote@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.6.1.tgz#f4781949cce402697127430ea3b3c5476f481767"
@@ -4780,16 +4513,7 @@ shell-quote@^1.6.1:
     array-reduce "~0.0.0"
     jsonify "~0.0.0"
 
-shelljs@^0.7.5:
-  version "0.7.8"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"
-  integrity sha1-3svPh0sNHl+3LhSxZKloMEjprLM=
-  dependencies:
-    glob "^7.0.0"
-    interpret "^1.0.0"
-    rechoir "^0.6.2"
-
-signal-exit@^3.0.0:
+signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
@@ -4811,10 +4535,12 @@ slash@^1.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
   integrity sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
 
-slice-ansi@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
-  integrity sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=
+slice-ansi@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-1.0.0.tgz#044f1a49d8842ff307aad6b505ed178bd950134d"
+  integrity sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -4964,37 +4690,12 @@ sshpk@^1.7.0:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
-standard-engine@~7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/standard-engine/-/standard-engine-7.0.0.tgz#ebb77b9c8fc2c8165ffa353bd91ba0dff41af690"
-  integrity sha1-67d7nI/CyBZf+jU72Rug3/Qa9pA=
-  dependencies:
-    deglob "^2.1.0"
-    get-stdin "^5.0.1"
-    minimist "^1.1.0"
-    pkg-conf "^2.0.0"
-
 standard-json@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/standard-json/-/standard-json-1.0.3.tgz#5b5b21d9418810dc5644c113d5163541dcd8faa6"
   integrity sha512-lhMP+KREBcfyyMe2ObJlEjJ0lc0ItA9uny83d9ZL6ggYtB79DuaAKCxJVoiflg5EV3D2rpuWn+n4+zXjWXk0sQ==
   dependencies:
     concat-stream "^1.5.0"
-
-standard@^10.0.3:
-  version "10.0.3"
-  resolved "https://registry.yarnpkg.com/standard/-/standard-10.0.3.tgz#7869bcbf422bdeeaab689a1ffb1fea9677dd50ea"
-  integrity sha512-JURZ+85ExKLQULckDFijdX5WHzN6RC7fgiZNSV4jFQVo+3tPoQGHyBrGekye/yf0aOfb4210EM5qPNlc2cRh4w==
-  dependencies:
-    eslint "~3.19.0"
-    eslint-config-standard "10.2.1"
-    eslint-config-standard-jsx "4.0.2"
-    eslint-plugin-import "~2.2.0"
-    eslint-plugin-node "~4.2.2"
-    eslint-plugin-promise "~3.5.0"
-    eslint-plugin-react "~6.10.0"
-    eslint-plugin-standard "~3.0.1"
-    standard-engine "~7.0.0"
 
 static-extend@^0.1.1:
   version "0.1.2"
@@ -5080,7 +4781,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-"string-width@^1.0.2 || 2", string-width@^2.0.0:
+"string-width@^1.0.2 || 2", string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
@@ -5137,11 +4838,6 @@ strip-bom@^2.0.0:
   dependencies:
     is-utf8 "^0.2.0"
 
-strip-bom@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
-  integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
-
 strip-indent@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
@@ -5149,7 +4845,7 @@ strip-indent@^1.0.1:
   dependencies:
     get-stdin "^4.0.1"
 
-strip-json-comments@~2.0.1:
+strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
@@ -5188,17 +4884,15 @@ syntax-error@^1.1.1:
   dependencies:
     acorn-node "^1.2.0"
 
-table@^3.7.8:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/table/-/table-3.8.3.tgz#2bbc542f0fda9861a755d3947fefd8b3f513855f"
-  integrity sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=
+table@^5.0.2:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/table/-/table-5.1.0.tgz#69a54644f6f01ad1628f8178715b408dc6bf11f7"
+  integrity sha512-e542in22ZLhD/fOIuXs/8yDZ9W61ltF8daM88rkRNtgTIct+vI2fTnAyu/Db2TCfEcI8i7mjZz6meLq0nW7TYg==
   dependencies:
-    ajv "^4.7.0"
-    ajv-keywords "^1.0.0"
-    chalk "^1.1.1"
-    lodash "^4.0.0"
-    slice-ansi "0.0.4"
-    string-width "^2.0.0"
+    ajv "^6.5.3"
+    lodash "^4.17.10"
+    slice-ansi "1.0.0"
+    string-width "^2.1.1"
 
 tap-colorize@^1.2.0:
   version "1.2.0"
@@ -5277,7 +4971,7 @@ tempy@0.1.0:
     temp-dir "^1.0.0"
     unique-string "^1.0.0"
 
-text-table@^0.2.0, text-table@~0.2.0:
+text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
@@ -5352,6 +5046,13 @@ timers-browserify@^1.0.1:
   dependencies:
     process "~0.11.0"
 
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
+  dependencies:
+    os-tmpdir "~1.0.2"
+
 to-arraybuffer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
@@ -5416,6 +5117,11 @@ trumpet@^1.7.1:
     inherits "^2.0.0"
     readable-stream "^1.0.27-1"
     through2 "^1.0.0"
+
+tslib@^1.9.0:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+  integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
 tty-browserify@~0.0.0:
   version "0.0.1"
@@ -5487,11 +5193,6 @@ union-value@^1.0.0:
     is-extendable "^0.1.1"
     set-value "^0.4.3"
 
-uniq@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
-  integrity sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=
-
 unique-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-1.0.0.tgz#9e1057cca851abb93398f8b33ae187b99caec11a"
@@ -5511,6 +5212,13 @@ unset-value@^1.0.0:
   dependencies:
     has-value "^0.3.1"
     isobject "^3.0.0"
+
+uri-js@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
+  integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
+  dependencies:
+    punycode "^2.1.0"
 
 urix@^0.1.0:
   version "0.1.0"
@@ -5539,13 +5247,6 @@ user-home@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190"
   integrity sha1-K1viOjK2Onyd640PKNSFcko98ZA=
-
-user-home@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/user-home/-/user-home-2.0.0.tgz#9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f"
-  integrity sha1-nHC/2Babwdy/SGBODwS4tJzenp8=
-  dependencies:
-    os-homedir "^1.0.0"
 
 util-deprecate@~1.0.1:
   version "1.0.2"
@@ -5606,6 +5307,13 @@ vm-browserify@~0.0.1:
   integrity sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=
   dependencies:
     indexof "0.0.1"
+
+which@^1.2.9:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
+  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  dependencies:
+    isexe "^2.0.0"
 
 wide-align@^1.1.0:
   version "1.1.3"


### PR DESCRIPTION
Introduces prettier + eslint instead of standard-js because formatters > style linters. run `yarn format` to format everything, or better yet configure your editor to format on save. The style is open to debate. Starting out with default aside from no semicolons and all trailing commas because trailing commas are great and semicolons are pointless if you're using a linter. Fight me.

Also removed class properties because they're non-standard, eslint doesn't like them, and they have the potential to cause confusion. Had to sprinkle some `bind`s about as a result (javascript classes are so broken 😢).

Also adds option to run tests in chrome because it sometimes throws stuff up that running them in electron doesn't, and copies the publish-please setup from chatkit-server-node.