### PR TITLE
Subscribe to own presence state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning Scheme](http://semver.org)
 ### Fixes
 
 - The `users` property on the room object.
+- Subscribe to user's own presence state.
 
 ## [1.0.3](https://github.com/pusher/chatkit-client-js/compare/1.0.2...1.0.3)
 

--- a/src/current-user.js
+++ b/src/current-user.js
@@ -557,18 +557,19 @@ export class CurrentUser {
       logger: this.logger,
       connectionTimeout: this.connectionTimeout,
     })
-    return this.presenceSubscription.connect().catch(err => {
-      this.logger.warn("error establishing presence subscription:", err)
-      throw err
-    })
+
+    return Promise.all([
+      this.userStore.fetchBasicUsers([this.id]),
+      this.subscribeToUserPresence(this.id),
+      this.presenceSubscription.connect().catch(err => {
+        this.logger.warn("error establishing presence subscription:", err)
+        throw err
+      }),
+    ])
   }
 
   subscribeToUserPresence(userId) {
     if (this.userPresenceSubscriptions[userId]) {
-      return Promise.resolve()
-    }
-
-    if (userId === this.id) {
       return Promise.resolve()
     }
 

--- a/tests/main.js
+++ b/tests/main.js
@@ -409,14 +409,31 @@ test(`added to room hook [creates Bob & Bob's room]`, t => {
 
 // Presence Subscription
 
+test("current user is online", t => {
+  fetchUser(t, "alice", {})
+    .then(alice => {
+      const myUser = alice.users.find(u => u.id === "alice")
+      t.false(myUser === undefined)
+      t.equal(myUser.presence.state, "online")
+      t.end()
+    })
+    .catch(endWithErr(t))
+  t.timeoutAfter(TEST_TIMEOUT)
+})
+
 test("user came online hook (presence sub)", t => {
   let alice
   fetchUser(t, "alice", {
     onPresenceChanged: (state, user) => {
+      if (user.id === "alice") {
+        return // ignore our own updates
+      }
+
       t.equal(state.current, "online")
       t.equal(state.previous, "unknown")
       t.equal(user.id, "bob")
       t.equal(user.presence.state, "online")
+
       alice.disconnect()
       t.end()
     },
@@ -440,10 +457,15 @@ test("user went offline hook (presence sub)", t => {
       if (state.previous === "unknown") {
         return // ignore the initial state, we only care about the transition
       }
+      if (user.id === "alice") {
+        return // ignore our own updates
+      }
+
       t.equal(state.current, "offline")
       t.equal(state.previous, "online")
       t.equal(user.id, "bob")
       t.equal(user.presence.state, "offline")
+
       alice.disconnect()
       t.end()
     },


### PR DESCRIPTION
It was always being shown as "unknown", as we explicitly did not
subscribe to it. But it's useful to be able to treat the current user
the same as any other when listing them.