### PR TITLE
Buffer room events

### DIFF
--- a/src/current-user.js
+++ b/src/current-user.js
@@ -28,8 +28,6 @@ import { UserSubscription } from "./user-subscription"
 import { PresenceSubscription } from "./presence-subscription"
 import { UserPresenceSubscription } from "./user-presence-subscription"
 import { CursorSubscription } from "./cursor-subscription"
-import { MessageSubscription } from "./message-subscription"
-import { MembershipSubscription } from "./membership-subscription"
 import { RoomSubscription } from "./room-subscription"
 import { Message } from "./message"
 import { SET_CURSOR_WAIT } from "./constants"
@@ -364,44 +362,18 @@ export class CurrentUser {
     }
     this.hooks.rooms[roomId] = hooks
     const roomSubscription = new RoomSubscription({
-      messageSub: new MessageSubscription({
-        roomId,
-        hooks: this.hooks,
-        messageLimit,
-        userId: this.id,
-        instance: this.apiInstance,
-        userStore: this.userStore,
-        roomStore: this.roomStore,
-        typingIndicators: this.typingIndicators,
-        logger: this.logger,
-        connectionTimeout: this.connectionTimeout,
-      }),
-      cursorSub: new CursorSubscription({
-        onNewCursorHook: cursor => {
-          if (
-            this.hooks.rooms[roomId] &&
-            this.hooks.rooms[roomId].onNewReadCursor &&
-            cursor.type === 0 &&
-            cursor.userId !== this.id
-          ) {
-            this.hooks.rooms[roomId].onNewReadCursor(cursor)
-          }
-        },
-        path: `/cursors/0/rooms/${encodeURIComponent(roomId)}`,
-        cursorStore: this.cursorStore,
-        instance: this.cursorsInstance,
-        logger: this.logger,
-        connectionTimeout: this.connectionTimeout,
-      }),
-      membershipSub: new MembershipSubscription({
-        roomId,
-        hooks: this.hooks,
-        instance: this.apiInstance,
-        userStore: this.userStore,
-        roomStore: this.roomStore,
-        logger: this.logger,
-        connectionTimeout: this.connectionTimeout,
-      }),
+      apiInstance: this.apiInstance,
+      connectionTimeout: this.connectionTimeout,
+      cursorStore: this.cursorStore,
+      cursorsInstance: this.cursorsInstance,
+      hooks: this.hooks,
+      logger: this.logger,
+      messageLimit,
+      roomId,
+      roomStore: this.roomStore,
+      typingIndicators: this.typingIndicators,
+      userId: this.id,
+      userStore: this.userStore,
     })
     this.roomSubscriptions[roomId] = roomSubscription
     return this.joinRoom({ roomId })

--- a/src/room-subscription.js
+++ b/src/room-subscription.js
@@ -1,8 +1,49 @@
+import { CursorSubscription } from "./cursor-subscription"
+import { MessageSubscription } from "./message-subscription"
+import { MembershipSubscription } from "./membership-subscription"
+
 export class RoomSubscription {
   constructor(options) {
-    this.messageSub = options.messageSub
-    this.cursorSub = options.cursorSub
-    this.membershipSub = options.membershipSub
+    this.messageSub = new MessageSubscription({
+      roomId: options.roomId,
+      hooks: options.hooks,
+      messageLimit: options.messageLimit,
+      userId: options.userId,
+      instance: options.apiInstance,
+      userStore: options.userStore,
+      roomStore: options.roomStore,
+      typingIndicators: options.typingIndicators,
+      logger: options.logger,
+      connectionTimeout: options.connectionTimeout,
+    })
+
+    this.cursorSub = new CursorSubscription({
+      onNewCursorHook: cursor => {
+        if (
+          options.hooks.rooms[options.roomId] &&
+          options.hooks.rooms[options.roomId].onNewReadCursor &&
+          cursor.type === 0 &&
+          cursor.userId !== options.userId
+        ) {
+          options.hooks.rooms[options.roomId].onNewReadCursor(cursor)
+        }
+      },
+      path: `/cursors/0/rooms/${encodeURIComponent(options.roomId)}`,
+      cursorStore: options.cursorStore,
+      instance: options.cursorsInstance,
+      logger: options.logger,
+      connectionTimeout: options.connectionTimeout,
+    })
+
+    this.membershipSub = new MembershipSubscription({
+      roomId: options.roomId,
+      hooks: options.hooks,
+      instance: options.apiInstance,
+      userStore: options.userStore,
+      roomStore: options.roomStore,
+      logger: options.logger,
+      connectionTimeout: options.connectionTimeout,
+    })
   }
 
   connect() {

--- a/tests/unit/membership-sub-reconnection.js
+++ b/tests/unit/membership-sub-reconnection.js
@@ -38,7 +38,12 @@ test("user joined (room level hook)", (t, userStore, roomStore) => {
     roomId,
     roomStore,
     userStore,
-    hooks: { rooms: { "42": { onUserJoined } }, global: {} },
+    onUserJoinedRoomHook: (room, user) => {
+      if (room.id === "42") {
+        onUserJoined(user)
+      }
+    },
+    onUserLeftRoomHook: () => {},
   })
 })
 
@@ -56,7 +61,8 @@ test("user joined (global hook)", (t, userStore, roomStore) => {
     roomId,
     roomStore,
     userStore,
-    hooks: { rooms: {}, global: { onUserJoinedRoom } },
+    onUserJoinedRoomHook: (room, user) => onUserJoinedRoom(room, user),
+    onUserLeftRoomHook: () => {},
   })
 })
 
@@ -72,7 +78,12 @@ test("user left (room level hook)", (t, userStore, roomStore) => {
     roomId,
     roomStore,
     userStore,
-    hooks: { rooms: { "42": { onUserLeft } }, global: {} },
+    onUserJoinedRoomHook: () => {},
+    onUserLeftRoomHook: (room, user) => {
+      if (room.id === "42") {
+        onUserLeft(user)
+      }
+    },
   })
 })
 
@@ -90,7 +101,8 @@ test("user joined (global hook)", (t, userStore, roomStore) => {
     roomId,
     roomStore,
     userStore,
-    hooks: { rooms: {}, global: { onUserLeftRoom } },
+    onUserJoinedRoomHook: () => {},
+    onUserLeftRoomHook: (room, user) => onUserLeftRoom(room, user),
   })
 })
 
@@ -100,7 +112,8 @@ test("room store memberships updated", (t, userStore, roomStore) => {
     roomId,
     roomStore,
     userStore,
-    hooks: { rooms: {}, global: {} },
+    onUserJoinedRoomHook: () => {},
+    onUserLeftRoomHook: () => {},
   }).then(() => {
     t.equal(roomStore.getSync(roomId).userIds, newUserIds)
     t.end()


### PR DESCRIPTION
Wait for all three components of the room subscription to be established before emitting events from any of them so we have all the information we need. Change involves passing events up to the RoomSubscription so that it can coordinate where before each component called the top-level hooks directly.