### PR TITLE
Subscribe to room race

### DIFF
--- a/src/current-user.js
+++ b/src/current-user.js
@@ -363,7 +363,7 @@ export class CurrentUser {
       this.roomSubscriptions[roomId].cancel()
     }
     this.hooks.rooms[roomId] = hooks
-    this.roomSubscriptions[roomId] = new RoomSubscription({
+    const roomSubscription = new RoomSubscription({
       messageSub: new MessageSubscription({
         roomId,
         hooks: this.hooks,
@@ -403,8 +403,9 @@ export class CurrentUser {
         connectionTimeout: this.connectionTimeout,
       }),
     })
+    this.roomSubscriptions[roomId] = roomSubscription
     return this.joinRoom({ roomId })
-      .then(room => this.roomSubscriptions[roomId].connect().then(() => room))
+      .then(room => roomSubscription.connect().then(() => room))
       .catch(err => {
         this.logger.warn(`error subscribing to room ${roomId}:`, err)
         throw err

--- a/src/room-subscription.js
+++ b/src/room-subscription.js
@@ -6,6 +6,11 @@ export class RoomSubscription {
   }
 
   connect() {
+    if (this.cancelled) {
+      return Promise.reject(
+        new Error("attempt to connect a cancelled room subscription"),
+      )
+    }
     return Promise.all([
       this.messageSub.connect(),
       this.cursorSub.connect(),
@@ -14,6 +19,7 @@ export class RoomSubscription {
   }
 
   cancel() {
+    this.cancelled = true
     this.messageSub.cancel()
     this.cursorSub.cancel()
     this.membershipSub.cancel()


### PR DESCRIPTION
Trying to reproduce #140 uncovered a couple of related issues.

- If two room subscriptions are on the go at once, it is possible to connect as the same one twice (since we access the room subscription from the global state). The platform library allows this, and will register your event handlers twice. Fixed by using a local reference to the subscription so that it can't change beneath us.
- Again, if two room subscriptions are made in very quick succession. The first one might be cancelled before it is connected, but the cancellation will then do nothing, and the connection will go ahead as normal, leading to the new and old connection both surviving. Fixed by denying an attempt to connect a cancelled subscription.