### PR TITLE
Add `withCredentials` options to the token provider

### DIFF
--- a/src/token-provider.js
+++ b/src/token-provider.js
@@ -3,13 +3,14 @@ import { sendRawRequest } from "@pusher/platform"
 import { appendQueryParams, typeCheck, unixSeconds, urlEncode } from "./utils"
 
 export class TokenProvider {
-  constructor({ url, queryParams, headers } = {}) {
+  constructor({ url, queryParams, headers, withCredentials } = {}) {
     typeCheck("url", "string", url)
     queryParams && typeCheck("queryParams", "object", queryParams)
     headers && typeCheck("headers", "object", headers)
     this.url = url
     this.queryParams = queryParams
     this.headers = headers
+    this.withCredentials = withCredentials
 
     this.fetchToken = this.fetchToken.bind(this)
     this.fetchFreshToken = this.fetchFreshToken.bind(this)
@@ -40,6 +41,7 @@ export class TokenProvider {
         "content-type": "application/x-www-form-urlencoded",
         ...this.headers,
       },
+      withCredentials: this.withCredentials,
     })
       .then(res => {
         const { access_token: token, expires_in: expiresIn } = JSON.parse(res)

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,9 +36,9 @@
     pusher-platform-node "~0.13.0"
 
 "@pusher/platform@^0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@pusher/platform/-/platform-0.16.1.tgz#d8da86c9261d2cf1b9d275893521bfc94aafa013"
-  integrity sha512-3GCY4oT5TUM83Cm6REz5ILpm9ZaQ8rg/kbYxf27VK3ErJGGZ4FhQKfaPkQRQZ1/+qImiMwWoDDD8GoqYpGT+vQ==
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@pusher/platform/-/platform-0.16.2.tgz#d6493b171903dd42a9fcd650a90d352af5e344c2"
+  integrity sha512-i8FHrurPFs2nmTDFHP1OMcFvtmZFGLUtOj46Ick/KOopTWnVv1FJkruMIV+wahP4mKl9e8XNzqe62HEXDh/n+A==
 
 "@types/node@^8.0.24":
   version "8.10.36"


### PR DESCRIPTION
Depends on https://github.com/pusher/pusher-platform-js/pull/96/files

TODO:
- [ ] Bump the `@pusher/platform` version