### PR TITLE
Online notifications

### DIFF
--- a/src/chat-manager.js
+++ b/src/chat-manager.js
@@ -67,6 +67,11 @@ export class ChatManager {
       serviceVersion: "v1",
       ...instanceOptions,
     })
+    this.pushNotificationsInstance = new Instance({
+      serviceName: "chatkit_push_notifications",
+      serviceVersion: "v1",
+      ...instanceOptions,
+    })
     // capturing the `instanceId` in a closure here as the `CurrentUser` model
     // doesn't need to be concerned about such details
     this.beamsInstanceInitFn =
@@ -98,6 +103,7 @@ export class ChatManager {
       cursorsInstance: this.cursorsInstance,
       presenceInstance: this.presenceInstance,
       beamsTokenProviderInstance: this.beamsTokenProviderInstance,
+      pushNotificationsInstance: this.pushNotificationsInstance,
       beamsInstanceInitFn: this.beamsInstanceInitFn,
       connectionTimeout: this.connectionTimeout,
     })

--- a/src/current-user.js
+++ b/src/current-user.js
@@ -29,6 +29,8 @@ import { UserSubscription } from "./user-subscription"
 import { PresenceSubscription } from "./presence-subscription"
 import { UserPresenceSubscription } from "./user-presence-subscription"
 import { RoomSubscription } from "./room-subscription"
+import { NotificationSubscription } from "./notification-subscription"
+import { showNotification } from "./notification"
 import { Message } from "./message"
 import { SET_CURSOR_WAIT } from "./constants"
 
@@ -43,6 +45,7 @@ export class CurrentUser {
     id,
     presenceInstance,
     beamsTokenProviderInstance,
+    pushNotificationsInstance,
     beamsInstanceInitFn,
   }) {
     this.hooks = {
@@ -58,6 +61,7 @@ export class CurrentUser {
     this.connectionTimeout = connectionTimeout
     this.presenceInstance = presenceInstance
     this.beamsTokenProviderInstance = beamsTokenProviderInstance
+    this.pushNotificationsInstance = pushNotificationsInstance
     this.beamsInstanceInitFn = beamsInstanceInitFn
     this.logger = serverInstanceV6.logger
     this.presenceStore = {}
@@ -639,40 +643,52 @@ export class CurrentUser {
   }
 
   enablePushNotifications(config = {}) {
-    try {
-      return this.beamsInstanceInitFn({
-        serviceWorkerRegistration: config.serviceWorkerRegistration,
-      })
-        .then(beamsClient => beamsClient.start())
-        .then(beamsClient => {
-          const fetchBeamsToken = userId =>
-            this.beamsTokenProviderInstance
-              .request({
-                method: "GET",
-                path: `/beams-tokens?user_id=${encodeURIComponent(userId)}`,
-              })
-              .then(JSON.parse)
-              .catch(req => {
-                return Promise.reject(
-                  `Internal error: ${req.statusCode} status code, info: ${
-                    req.info.error_description
-                  }`,
-                )
-              })
+    const notificationSubscription = new NotificationSubscription({
+      onNotificationHook: showNotification,
+      userId: this.id,
+      instance: this.pushNotificationsInstance,
+      logger: this.logger,
+      connectionTimeout: this.connectionTimeout,
+    })
+    this.notificationSubscription = notificationSubscription
 
-          return beamsClient.setUserId(this.id, {
-            fetchToken: fetchBeamsToken,
+    try {
+      return Promise.all([
+        this.beamsInstanceInitFn({
+          serviceWorkerRegistration: config.serviceWorkerRegistration,
+        })
+          .then(beamsClient => beamsClient.start())
+          .then(beamsClient => {
+            const fetchBeamsToken = userId =>
+              this.beamsTokenProviderInstance
+                .request({
+                  method: "GET",
+                  path: `/beams-tokens?user_id=${encodeURIComponent(userId)}`,
+                })
+                .then(JSON.parse)
+                .catch(req => {
+                  return Promise.reject(
+                    `Internal error: ${req.statusCode} status code, info: ${
+                      req.info.error_description
+                    }`,
+                  )
+                })
+
+            return beamsClient.setUserId(this.id, {
+              fetchToken: fetchBeamsToken,
+            })
           })
-        })
-        .catch(err => {
-          this.logger.warn(
-            `Chatkit error when enabling push notifications:`,
-            err,
-          )
-          return Promise.reject(
-            `Chatkit error when enabling push notifications: ${err}`,
-          )
-        })
+          .catch(err => {
+            this.logger.warn(
+              `Chatkit error when enabling push notifications:`,
+              err,
+            )
+            return Promise.reject(
+              `Chatkit error when enabling push notifications: ${err}`,
+            )
+          }),
+        notificationSubscription.connect(),
+      ])
     } catch (err) {
       this.logger.warn(`Chatkit error when enabling push notifications:`, err)
       return Promise.reject(
@@ -684,6 +700,9 @@ export class CurrentUser {
   disconnect() {
     this.userSubscription.cancel()
     this.presenceSubscription.cancel()
+    if (this.notificationSubscription) {
+      this.notificationSubscription.cancel()
+    }
     forEachObjIndexed(sub => sub.cancel(), this.roomSubscriptions)
     forEachObjIndexed(sub => sub.cancel(), this.userPresenceSubscriptions)
   }

--- a/src/current-user.js
+++ b/src/current-user.js
@@ -644,7 +644,8 @@ export class CurrentUser {
 
   enablePushNotifications(config = {}) {
     const notificationSubscription = new NotificationSubscription({
-      onNotificationHook: showNotification,
+      onNotificationHook: ({ notification, data }) =>
+        showNotification({ notification, data, onClick: config.onClick }),
       userId: this.id,
       instance: this.pushNotificationsInstance,
       logger: this.logger,

--- a/src/notification-subscription.js
+++ b/src/notification-subscription.js
@@ -1,0 +1,57 @@
+export class NotificationSubscription {
+  constructor(options) {
+    this.onNotificationHook = options.onNotificationHook
+    this.userId = options.userId
+    this.instance = options.instance
+    this.logger = options.logger
+    this.connectionTimeout = options.connectionTimeout
+
+    this.connect = this.connect.bind(this)
+    this.cancel = this.cancel.bind(this)
+    this.onEvent = this.onEvent.bind(this)
+    this.onNotification = this.onNotification.bind(this)
+  }
+
+  connect() {
+    return new Promise((resolve, reject) => {
+      this.timeout = setTimeout(() => {
+        reject(new Error("notification subscription timed out"))
+      }, this.connectionTimeout)
+      this.sub = this.instance.subscribeNonResuming({
+        path: `/users/${encodeURIComponent(this.userId)}`,
+        listeners: {
+          onOpen: () => {
+            clearTimeout(this.timeout)
+            resolve()
+          },
+          onError: err => {
+            clearTimeout(this.timeout)
+            reject(err)
+          },
+          onEvent: this.onEvent,
+        },
+      })
+    })
+  }
+
+  cancel() {
+    clearTimeout(this.timeout)
+    try {
+      this.sub && this.sub.unsubscribe()
+    } catch (err) {
+      this.logger.debug("error when cancelling notification subscription", err)
+    }
+  }
+
+  onEvent({ body }) {
+    switch (body.event_name) {
+      case "push_notification":
+        this.onNotification(body.data)
+        break
+    }
+  }
+
+  onNotification(data) {
+    this.onNotificationHook(data)
+  }
+}

--- a/src/notification.js
+++ b/src/notification.js
@@ -1,5 +1,8 @@
 export function showNotification({ notification, data }) {
-  // TODO only if the tab isn't visible!
+  if (document.visibilityState !== "hidden") {
+    return
+  }
+
   const n = new Notification(notification.title || "", {
     body: notification.body || "",
     icon: notification.icon,

--- a/src/notification.js
+++ b/src/notification.js
@@ -1,4 +1,4 @@
-export function showNotification({ notification, data }) {
+export function showNotification({ notification, data, onClick }) {
   if (document.visibilityState !== "hidden") {
     return
   }
@@ -14,6 +14,9 @@ export function showNotification({ notification, data }) {
   n.onclick = e => {
     e.preventDefault()
     window.focus()
+    if (onClick) {
+      onClick(e.target.data.chatkit)
+    }
     e.target.close()
   }
 }

--- a/src/notification.js
+++ b/src/notification.js
@@ -1,0 +1,16 @@
+export function showNotification({ notification, data }) {
+  // TODO only if the tab isn't visible!
+  const n = new Notification(notification.title || "", {
+    body: notification.body || "",
+    icon: notification.icon,
+    data: Object.assign(data, {
+      pusher: { deep_link: notification.deep_link },
+    }),
+  })
+
+  n.onclick = e => {
+    e.preventDefault()
+    window.focus()
+    e.target.close()
+  }
+}


### PR DESCRIPTION
Subscribes to the online notification subscription on the push_notifications service and displays notifications received if the tab is hidden. Focusses the tab on click and provides an optional `onClick` hook that receives the room ID so that the application can focus the correct room.

Only enabled if push notifications proper are enabled. We might want to provide an option to enable this independently in the future. This has been manually tested, but we will be writing automated tests for it with the new framework.