### PR TITLE
Bump Beams SDK version to get better error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This project adheres to [Semantic Versioning Scheme](http://semver.org)
 
 ## [Unreleased](https://github.com/pusher/chatkit-client-js/compare/1.13.0...HEAD)
 
+### Fixes
+
+ - Bump push-notifications-web version. This will return a descriptive error
+   if an invalid service worker registration is given to the SDK.
+
 ## [1.13.0](https://github.com/pusher/chatkit-client-js/compare/1.12.1...1.13.0)
 
 ### Additions

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@pusher/chatkit-server": "^2.0.1",
     "@pusher/platform": "^0.17.0",
-    "@pusher/push-notifications-web": "0.9.0",
+    "@pusher/push-notifications-web": "0.9.1",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-plugin-external-helpers": "^6.22.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -345,10 +345,10 @@
   resolved "https://registry.yarnpkg.com/@pusher/platform/-/platform-0.17.0.tgz#8e5b8bdfbbe512c93fe6b8994f3f55311306f5c1"
   integrity sha512-GnW5gK+vRCRMUmZalJABV5e4NU1PxHPazhXSOaECC3DjY6lp43RLy3KPfj7LZ5NDRDwQojAiD0YmtkFruG3+gQ==
 
-"@pusher/push-notifications-web@0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@pusher/push-notifications-web/-/push-notifications-web-0.9.0.tgz#acecdaa0375981c2dc8fff00f36c0827d5d53336"
-  integrity sha512-ULmw+XKffL7QW4/Qxkpc8gFtjLMWSHeTf8eXxSW68La87eO7NeOOwvdr+PqgOuwc3GyQ1Abh07zXBlJ5yfTR4w==
+"@pusher/push-notifications-web@0.9.1":
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/@pusher/push-notifications-web/-/push-notifications-web-0.9.1.tgz#1ce79f9d3b43ae72a13a10f5f789083cf0e55bb4"
+  integrity sha512-ncJqR4ToUc55i8x1KCeI8o8svNjWowMnGyNJGMfeFj/IXuGuEcgedgKrBMkwiFeu2F0RxOErNhLIm7KJUGt7HA==
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"


### PR DESCRIPTION
Currently, if you pass a service worker registration with an invalid scope when enabling notifications, the SDK fails silently.
This Beams SDK version returns a descriptive error instead: https://github.com/pusher/push-notifications-web/commit/25a1a6a7b60e7e2feec65bd98aa3eb3d44026a9e#diff-ecdae514d2d75de322aae0d24a1a6c48R93